### PR TITLE
Split LitUI in BaseLitUI and LitUI

### DIFF
--- a/Assets/ScriptableRenderLoop/HDRenderLoop/Material/Lit/Editor/LitUI.cs
+++ b/Assets/ScriptableRenderLoop/HDRenderLoop/Material/Lit/Editor/LitUI.cs
@@ -4,59 +4,15 @@ using UnityEngine.Rendering;
 
 namespace UnityEditor
 {
-    internal class LitGUI : ShaderGUI
+    public abstract class BaseLitGUI : ShaderGUI
     {
-        public enum SurfaceType
+        protected static class Styles
         {
-            Opaque,
-            Transparent
-        }
-        public enum BlendMode
-        {
-            Lerp,
-            Add,
-            SoftAdd,
-            Multiply,
-            Premultiply
-        }
-
-        public enum SmoothnessMapChannel
-        {
-            MaskAlpha,
-            AlbedoAlpha,
-        }
-        public enum EmissiveColorMode
-        {
-            UseEmissiveColor,
-            UseEmissiveMask,
-        }
-        public enum DoubleSidedMode
-        {
-            None,
-            DoubleSided,
-            DoubleSidedLightingFlip,
-            DoubleSidedLightingMirror,
-        }
-
-        public enum NormalMapSpace
-        {
-            TangentSpace,
-            ObjectSpace,
-        }
-
-        public enum HeightmapMode
-        {
-            Parallax,
-            Displacement,
-        }
-        public enum DetailMapMode
-        {
-            DetailWithNormal,
-            DetailWithAOHeight,
-        }
-
-        private static class Styles
-        {
+            public enum DetailMapMode
+            {
+                DetailWithNormal,
+                DetailWithAOHeight,
+            }
             public static string OptionText = "Options";
             public static string SurfaceTypeText = "Surface Type";
             public static string BlendModeText = "Blend Mode";
@@ -120,123 +76,41 @@ namespace UnityEditor
 
         }
 
-        MaterialProperty surfaceType = null;
-        MaterialProperty blendMode = null;
-        MaterialProperty UVDetail = null;
-        MaterialProperty alphaCutoff = null;
-        MaterialProperty alphaCutoffEnable = null;
-        MaterialProperty doubleSidedMode = null;
-        MaterialProperty smoothnessMapChannel = null;
-        MaterialProperty emissiveColorMode = null;
-        MaterialProperty detailMapMode = null;
-
-        MaterialProperty baseColor = null;
-        MaterialProperty baseColorMap = null;
-        MaterialProperty metallic = null;
-        MaterialProperty smoothness = null;
-        MaterialProperty maskMap = null;
-        MaterialProperty specularOcclusionMap = null;
-        MaterialProperty normalMap = null;
-        MaterialProperty normalMapSpace = null;
-        MaterialProperty heightMap = null;
-        MaterialProperty heightScale = null;
-        MaterialProperty heightBias = null;
-        MaterialProperty tangentMap = null;
-        MaterialProperty anisotropy = null;
-        MaterialProperty anisotropyMap = null;
-        MaterialProperty heightMapMode = null;
-        MaterialProperty detailMap = null;
-        MaterialProperty detailMask = null;
-        MaterialProperty detailAlbedoScale = null;
-        MaterialProperty detailNormalScale = null;
-        MaterialProperty detailSmoothnessScale = null;
-        MaterialProperty detailHeightScale = null;
-        MaterialProperty detailAOScale = null;
-        MaterialProperty emissiveColor = null;
-        MaterialProperty emissiveColorMap = null;
-        MaterialProperty emissiveIntensity = null;
-//	MaterialProperty subSurfaceRadius = null;
-//	MaterialProperty subSurfaceRadiusMap = null;
-
-        protected MaterialEditor m_MaterialEditor;
-
-        protected const string kSurfaceType = "_SurfaceType";
-        protected const string kBlendMode = "_BlendMode";
-        protected const string kUVDetail = "_UVDetail";
-        protected const string kAlphaCutoff = "_AlphaCutoff";
-        protected const string kAlphaCutoffEnabled = "_AlphaCutoffEnable";
-        protected const string kDoubleSidedMode = "_DoubleSidedMode";
-        protected const string kSmoothnessTextureChannelProp = "_SmoothnessTextureChannel";
-        protected const string kEmissiveColorMode = "_EmissiveColorMode";
-        protected const string kNormalMapSpace = "_NormalMapSpace";
-        protected const string kHeightMapMode = "_HeightMapMode";
-        protected const string kDetailMapMode = "_DetailMapMode";
-
-        protected const string kNormalMap = "_NormalMap";
-        protected const string kMaskMap = "_MaskMap";
-        protected const string kspecularOcclusionMap = "_SpecularOcclusionMap";
-        protected const string kEmissiveColorMap = "_EmissiveColorMap";
-        protected const string kHeightMap = "_HeightMap";
-        protected const string kTangentMap = "_TangentMap";
-        protected const string kAnisotropyMap = "_AnisotropyMap";
-        protected const string kDetailMap = "_DetailMap";
-        protected const string kDetailMask = "_DetailMask";
-        protected const string kDetailAlbedoScale = "_DetailAlbedoScale";
-        protected const string kDetailNormalScale = "_DetailNormalScale";
-        protected const string kDetailSmoothnessScale = "_DetailSmoothnessScale";
-        protected const string kDetailHeightScale = "_DetailHeightScale";
-        protected const string kDetailAOScale = "_DetailAOScale";
-
-        public void FindOptionProperties(MaterialProperty[] props)
+        public enum SurfaceType
         {
-            surfaceType = FindProperty(kSurfaceType, props);
-            blendMode = FindProperty(kBlendMode, props);
-            UVDetail = FindProperty(kUVDetail, props);
-            alphaCutoff = FindProperty(kAlphaCutoff, props);
-            alphaCutoffEnable = FindProperty(kAlphaCutoffEnabled, props);
-            doubleSidedMode = FindProperty(kDoubleSidedMode, props);
-            smoothnessMapChannel = FindProperty(kSmoothnessTextureChannelProp, props);
-            emissiveColorMode = FindProperty(kEmissiveColorMode, props);
-            normalMapSpace = FindProperty(kNormalMapSpace, props);
-            heightMapMode = FindProperty(kHeightMapMode, props);
-            detailMapMode = FindProperty(kDetailMapMode, props);
+            Opaque,
+            Transparent
+        }
+        public enum BlendMode
+        {
+            Lerp,
+            Add,
+            SoftAdd,
+            Multiply,
+            Premultiply
+        }
+        public enum DoubleSidedMode
+        {
+            None,
+            DoubleSided,
+            DoubleSidedLightingFlip,
+            DoubleSidedLightingMirror,
         }
 
-        public void FindInputProperties(MaterialProperty[] props)
+        void SurfaceTypePopup()
         {
-            baseColor = FindProperty("_BaseColor", props);
-            baseColorMap = FindProperty("_BaseColorMap", props);
-            metallic = FindProperty("_Metallic", props);
-            smoothness = FindProperty("_Smoothness", props);
-            maskMap = FindProperty(kMaskMap, props);
-            specularOcclusionMap = FindProperty(kspecularOcclusionMap, props);
-            normalMap = FindProperty(kNormalMap, props);
-            heightMap = FindProperty(kHeightMap, props);
-            heightScale = FindProperty("_HeightScale", props);
-            heightBias = FindProperty("_HeightBias", props);
-            tangentMap = FindProperty("_TangentMap", props);
-            anisotropy = FindProperty("_Anisotropy", props);
-            anisotropyMap = FindProperty("_AnisotropyMap", props);
-            emissiveColor = FindProperty("_EmissiveColor", props);
-            emissiveColorMap = FindProperty(kEmissiveColorMap, props);
-            emissiveIntensity = FindProperty("_EmissiveIntensity", props);
-            detailMap = FindProperty(kDetailMap, props);
-            detailMask = FindProperty(kDetailMask, props);
-            detailAlbedoScale = FindProperty(kDetailAlbedoScale, props);
-            detailNormalScale = FindProperty(kDetailNormalScale, props);
-            detailSmoothnessScale = FindProperty(kDetailSmoothnessScale, props);
-            detailHeightScale = FindProperty(kDetailHeightScale, props);
-            detailAOScale = FindProperty(kDetailAOScale, props);
-        }
+            EditorGUI.showMixedValue = surfaceType.hasMixedValue;
+            var mode = (SurfaceType)surfaceType.floatValue;
 
-        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
-        {
-            FindOptionProperties(props); // MaterialProperties can be animated so we do not cache them but fetch them every event to ensure animated values are updated correctly
-            FindInputProperties(props);
+            EditorGUI.BeginChangeCheck();
+            mode = (SurfaceType)EditorGUILayout.Popup(Styles.SurfaceTypeText, (int)mode, Styles.surfaceTypeNames);
+            if (EditorGUI.EndChangeCheck())
+            {
+                m_MaterialEditor.RegisterPropertyChangeUndo("Surface Type");
+                surfaceType.floatValue = (float)mode;
+            }
 
-            m_MaterialEditor = materialEditor;
-            Material material = materialEditor.target as Material;
-            ShaderPropertiesGUI(material);
+            EditorGUI.showMixedValue = false;
         }
 
         protected void ShaderOptionsGUI()
@@ -258,134 +132,7 @@ namespace UnityEditor
             EditorGUI.indentLevel--;
         }
 
-        protected void ShaderInputOptionsGUI()
-        {
-            EditorGUI.indentLevel++;
-            GUILayout.Label(Styles.InputsOptionsText, EditorStyles.boldLabel);
-            m_MaterialEditor.ShaderProperty(smoothnessMapChannel, Styles.smoothnessMapChannelText.text);
-            m_MaterialEditor.ShaderProperty(emissiveColorMode, Styles.emissiveColorModeText.text);
-            m_MaterialEditor.ShaderProperty(normalMapSpace, Styles.normalMapSpaceText.text);
-            m_MaterialEditor.ShaderProperty(heightMapMode, Styles.heightMapModeText.text);
-            m_MaterialEditor.ShaderProperty(detailMapMode, Styles.detailMapModeText.text);
-            EditorGUI.indentLevel--;
-        }
-
-        protected void ShaderInputGUI()
-        {
-            EditorGUI.indentLevel++;
-            bool smoothnessInAlbedoAlpha = (SmoothnessMapChannel)smoothnessMapChannel.floatValue == SmoothnessMapChannel.AlbedoAlpha;
-            bool useEmissiveMask = (EmissiveColorMode)emissiveColorMode.floatValue == EmissiveColorMode.UseEmissiveMask;
-            bool useDetailMapWithNormal = (DetailMapMode)detailMapMode.floatValue == DetailMapMode.DetailWithNormal;
-
-            GUILayout.Label(Styles.InputsText, EditorStyles.boldLabel);
-            m_MaterialEditor.TexturePropertySingleLine(smoothnessInAlbedoAlpha ? Styles.baseColorSmoothnessText : Styles.baseColorText, baseColorMap, baseColor);
-            m_MaterialEditor.ShaderProperty(metallic, Styles.metallicText);
-            m_MaterialEditor.ShaderProperty(smoothness, Styles.smoothnessText);
-
-            if (smoothnessInAlbedoAlpha && useEmissiveMask)
-                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapEText, maskMap);
-            else if (smoothnessInAlbedoAlpha && !useEmissiveMask)
-                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapText, maskMap);
-            else if (!smoothnessInAlbedoAlpha && useEmissiveMask)
-                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapESText, maskMap);
-            else if (!smoothnessInAlbedoAlpha && !useEmissiveMask)
-                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapSText, maskMap);
-
-            m_MaterialEditor.TexturePropertySingleLine(Styles.specularOcclusionMapText, specularOcclusionMap);
-
-            m_MaterialEditor.TexturePropertySingleLine(Styles.normalMapText, normalMap);
-
-            m_MaterialEditor.TexturePropertySingleLine(Styles.heightMapText, heightMap, heightScale, heightBias);
-
-            m_MaterialEditor.TexturePropertySingleLine(Styles.tangentMapText, tangentMap);
-
-            m_MaterialEditor.ShaderProperty(anisotropy, Styles.anisotropyText);
-            
-            m_MaterialEditor.TexturePropertySingleLine(Styles.anisotropyMapText, anisotropyMap);
-
-            EditorGUILayout.Space();
-            GUILayout.Label(Styles.detailText, EditorStyles.boldLabel);
-
-            m_MaterialEditor.TexturePropertySingleLine(Styles.detailMaskText, detailMask); 
-			m_MaterialEditor.ShaderProperty(UVDetail, Styles.uvSetLabel.text);          
-
-            if (useDetailMapWithNormal)
-            {
-                m_MaterialEditor.TexturePropertySingleLine(Styles.detailMapNormalText, detailMap);
-            }
-            else
-            {
-                m_MaterialEditor.TexturePropertySingleLine(Styles.detailMapAOHeightText, detailMap);
-            }
-            m_MaterialEditor.TextureScaleOffsetProperty(detailMap);
-            EditorGUI.indentLevel++;
-            m_MaterialEditor.ShaderProperty(detailAlbedoScale, Styles.detailAlbedoScaleText);
-            m_MaterialEditor.ShaderProperty(detailNormalScale, Styles.detailNormalScaleText);
-            m_MaterialEditor.ShaderProperty(detailSmoothnessScale, Styles.detailSmoothnessScaleText);
-            m_MaterialEditor.ShaderProperty(detailHeightScale, Styles.detailHeightScaleText);
-            m_MaterialEditor.ShaderProperty(detailAOScale, Styles.detailAOScaleText);
-            EditorGUI.indentLevel--;
-
-            EditorGUILayout.Space();
-            GUILayout.Label(Styles.lightingText, EditorStyles.boldLabel);
-
-            if (!useEmissiveMask)
-            {
-                m_MaterialEditor.TexturePropertySingleLine(Styles.emissiveText, emissiveColorMap, emissiveColor);
-            }
-            m_MaterialEditor.ShaderProperty(emissiveIntensity, Styles.emissiveIntensityText);
-            m_MaterialEditor.LightmapEmissionProperty(MaterialEditor.kMiniTextureFieldLabelIndentLevel + 1);
-
-            EditorGUI.indentLevel--;
-        }
-
-        public void ShaderPropertiesGUI(Material material)
-        {
-            // Use default labelWidth
-            EditorGUIUtility.labelWidth = 0f;
-
-            // Detect any changes to the material
-            EditorGUI.BeginChangeCheck();
-            {
-                ShaderOptionsGUI();
-                EditorGUILayout.Space();
-
-                ShaderInputOptionsGUI();
-
-                EditorGUILayout.Space();
-                ShaderInputGUI();
-            }
-
-            if (EditorGUI.EndChangeCheck())
-            {
-                foreach (var obj in m_MaterialEditor.targets)
-                    SetupMaterial((Material)obj);
-            }
-        }
-
-        // TODO: try to setup minimun value to fall back to standard shaders and reverse
-        public override void AssignNewShaderToMaterial(Material material, Shader oldShader, Shader newShader)
-        {
-            base.AssignNewShaderToMaterial(material, oldShader, newShader);
-        }
-
-        void SurfaceTypePopup()
-        {
-            EditorGUI.showMixedValue = surfaceType.hasMixedValue;
-            var mode = (SurfaceType)surfaceType.floatValue;
-
-            EditorGUI.BeginChangeCheck();
-            mode = (SurfaceType)EditorGUILayout.Popup(Styles.SurfaceTypeText, (int)mode, Styles.surfaceTypeNames);
-            if (EditorGUI.EndChangeCheck())
-            {
-                m_MaterialEditor.RegisterPropertyChangeUndo("Surface Type");
-                surfaceType.floatValue = (float)mode;
-            }
-
-            EditorGUI.showMixedValue = false;
-        }
-
-        void BlendModePopup()
+        private void BlendModePopup()
         {
             EditorGUI.showMixedValue = blendMode.hasMixedValue;
             var mode = (BlendMode)blendMode.floatValue;
@@ -401,39 +148,18 @@ namespace UnityEditor
             EditorGUI.showMixedValue = false;
         }
 
-        protected virtual void SetupKeywordsForInputMaps(Material material)
+        protected void FindOptionProperties(MaterialProperty[] props)
         {
-            SetKeyword(material, "_NORMALMAP", material.GetTexture(kNormalMap) || material.GetTexture(kDetailMap)); // With details map, we always use a normal map and Unity provide a default (0, 0, 1) normal map for ir
-            SetKeyword(material, "_MASKMAP", material.GetTexture(kMaskMap));
-            SetKeyword(material, "_SPECULAROCCLUSIONMAP", material.GetTexture(kspecularOcclusionMap));
-            SetKeyword(material, "_EMISSIVE_COLOR_MAP", material.GetTexture(kEmissiveColorMap));
-            SetKeyword(material, "_HEIGHTMAP", material.GetTexture(kHeightMap));
-            SetKeyword(material, "_TANGENTMAP", material.GetTexture(kTangentMap));
-            SetKeyword(material, "_ANISOTROPYMAP", material.GetTexture(kAnisotropyMap));
-            SetKeyword(material, "_DETAIL_MAP", material.GetTexture(kDetailMap));
-        }
-
-        protected virtual void SetupEmissionGIFlags(Material material)
-        {
-            // Setup lightmap emissive flags
-
-            MaterialGlobalIlluminationFlags flags = material.globalIlluminationFlags;
-            if ((flags & (MaterialGlobalIlluminationFlags.BakedEmissive | MaterialGlobalIlluminationFlags.RealtimeEmissive)) != 0)
-            {
-                if (ShouldEmissionBeEnabled(material))
-                    flags &= ~MaterialGlobalIlluminationFlags.EmissiveIsBlack;
-                else
-                    flags |= MaterialGlobalIlluminationFlags.EmissiveIsBlack;
-
-                material.globalIlluminationFlags = flags;
-            }
+            surfaceType = FindProperty(kSurfaceType, props);
+            blendMode = FindProperty(kBlendMode, props);
+            alphaCutoff = FindProperty(kAlphaCutoff, props);
+            alphaCutoffEnable = FindProperty(kAlphaCutoffEnabled, props);
+            doubleSidedMode = FindProperty(kDoubleSidedMode, props);
+            FindInputOptionProperties(props);
         }
 
         protected void SetupMaterial(Material material)
         {
-            // Note: keywords must be based on Material value not on MaterialProperty due to multi-edit & material animation
-            // (MaterialProperty value might come from renderer material property block)
-
             bool alphaTestEnable = material.GetFloat(kAlphaCutoffEnabled) == 1.0;
             SurfaceType surfaceType = (SurfaceType)material.GetFloat(kSurfaceType);
             BlendMode blendMode = (BlendMode)material.GetFloat(kBlendMode);
@@ -508,6 +234,314 @@ namespace UnityEditor
             }
 
             SetKeyword(material, "_ALPHATEST_ON", alphaTestEnable);
+            SetupInputMaterial(material);
+        }
+
+        protected void SetKeyword(Material m, string keyword, bool state)
+        {
+            if (state)
+                m.EnableKeyword(keyword);
+            else
+                m.DisableKeyword(keyword);
+        }
+
+        public void ShaderPropertiesGUI(Material material)
+        {
+            // Use default labelWidth
+            EditorGUIUtility.labelWidth = 0f;
+
+            // Detect any changes to the material
+            EditorGUI.BeginChangeCheck();
+            {
+                ShaderOptionsGUI();
+                EditorGUILayout.Space();
+
+                ShaderInputOptionsGUI();
+
+                EditorGUILayout.Space();
+                ShaderInputGUI();
+            }
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                foreach (var obj in m_MaterialEditor.targets)
+                    SetupMaterial((Material)obj);
+            }
+        }
+
+        public override void OnGUI(MaterialEditor materialEditor, MaterialProperty[] props)
+        {
+            FindOptionProperties(props); // MaterialProperties can be animated so we do not cache them but fetch them every event to ensure animated values are updated correctly
+            FindInputProperties(props);
+
+            m_MaterialEditor = materialEditor;
+            Material material = materialEditor.target as Material;
+            ShaderPropertiesGUI(material);
+        }
+
+        protected MaterialEditor m_MaterialEditor;
+
+        private MaterialProperty surfaceType = null;
+        private MaterialProperty alphaCutoffEnable = null;
+        private MaterialProperty blendMode = null;
+        private MaterialProperty alphaCutoff = null;
+        private MaterialProperty doubleSidedMode = null;
+ 
+        private const string kSurfaceType = "_SurfaceType";
+        private const string kBlendMode = "_BlendMode";
+        private const string kAlphaCutoff = "_AlphaCutoff";
+        private const string kAlphaCutoffEnabled = "_AlphaCutoffEnable";
+        private const string kDoubleSidedMode = "_DoubleSidedMode";
+        protected static string[] reservedProperties = new string[] { kSurfaceType, kBlendMode, kAlphaCutoff, kAlphaCutoffEnabled, kDoubleSidedMode };
+
+        protected abstract void FindInputProperties(MaterialProperty[] props);
+        protected abstract void ShaderInputGUI();
+        protected abstract void ShaderInputOptionsGUI();
+        protected abstract void FindInputOptionProperties(MaterialProperty[] props);
+        protected abstract void SetupInputMaterial(Material material);
+    }
+
+    class LitGUI : BaseLitGUI
+    {
+        public enum SmoothnessMapChannel
+        {
+            MaskAlpha,
+            AlbedoAlpha,
+        }
+        public enum EmissiveColorMode
+        {
+            UseEmissiveColor,
+            UseEmissiveMask,
+        }
+ 
+        public enum NormalMapSpace
+        {
+            TangentSpace,
+            ObjectSpace,
+        }
+
+        public enum HeightmapMode
+        {
+            Parallax,
+            Displacement,
+        }
+        public enum DetailMapMode
+        {
+            DetailWithNormal,
+            DetailWithAOHeight,
+        }
+
+        MaterialProperty UVDetail = null;
+        MaterialProperty smoothnessMapChannel = null;
+        MaterialProperty emissiveColorMode = null;
+        MaterialProperty detailMapMode = null;
+
+        MaterialProperty baseColor = null;
+        MaterialProperty baseColorMap = null;
+        MaterialProperty metallic = null;
+        MaterialProperty smoothness = null;
+        MaterialProperty maskMap = null;
+        MaterialProperty specularOcclusionMap = null;
+        MaterialProperty normalMap = null;
+        MaterialProperty normalMapSpace = null;
+        MaterialProperty heightMap = null;
+        MaterialProperty heightScale = null;
+        MaterialProperty heightBias = null;
+        MaterialProperty tangentMap = null;
+        MaterialProperty anisotropy = null;
+        MaterialProperty anisotropyMap = null;
+        MaterialProperty heightMapMode = null;
+        MaterialProperty detailMap = null;
+        MaterialProperty detailMask = null;
+        MaterialProperty detailAlbedoScale = null;
+        MaterialProperty detailNormalScale = null;
+        MaterialProperty detailSmoothnessScale = null;
+        MaterialProperty detailHeightScale = null;
+        MaterialProperty detailAOScale = null;
+        MaterialProperty emissiveColor = null;
+        MaterialProperty emissiveColorMap = null;
+        MaterialProperty emissiveIntensity = null;
+//	MaterialProperty subSurfaceRadius = null;
+//	MaterialProperty subSurfaceRadiusMap = null;
+
+        protected const string kUVDetail = "_UVDetail";
+        protected const string kSmoothnessTextureChannelProp = "_SmoothnessTextureChannel";
+        protected const string kEmissiveColorMode = "_EmissiveColorMode";
+        protected const string kNormalMapSpace = "_NormalMapSpace";
+        protected const string kHeightMapMode = "_HeightMapMode";
+        protected const string kDetailMapMode = "_DetailMapMode";
+
+        protected const string kNormalMap = "_NormalMap";
+        protected const string kMaskMap = "_MaskMap";
+        protected const string kspecularOcclusionMap = "_SpecularOcclusionMap";
+        protected const string kEmissiveColorMap = "_EmissiveColorMap";
+        protected const string kHeightMap = "_HeightMap";
+        protected const string kTangentMap = "_TangentMap";
+        protected const string kAnisotropyMap = "_AnisotropyMap";
+        protected const string kDetailMap = "_DetailMap";
+        protected const string kDetailMask = "_DetailMask";
+        protected const string kDetailAlbedoScale = "_DetailAlbedoScale";
+        protected const string kDetailNormalScale = "_DetailNormalScale";
+        protected const string kDetailSmoothnessScale = "_DetailSmoothnessScale";
+        protected const string kDetailHeightScale = "_DetailHeightScale";
+        protected const string kDetailAOScale = "_DetailAOScale";
+
+        override protected void FindInputOptionProperties(MaterialProperty[] props)
+        {
+            UVDetail = FindProperty(kUVDetail, props);
+            smoothnessMapChannel = FindProperty(kSmoothnessTextureChannelProp, props);
+            emissiveColorMode = FindProperty(kEmissiveColorMode, props);
+            normalMapSpace = FindProperty(kNormalMapSpace, props);
+            heightMapMode = FindProperty(kHeightMapMode, props);
+            detailMapMode = FindProperty(kDetailMapMode, props);
+        }
+
+        override protected void FindInputProperties(MaterialProperty[] props)
+        {
+            baseColor = FindProperty("_BaseColor", props);
+            baseColorMap = FindProperty("_BaseColorMap", props);
+            metallic = FindProperty("_Metallic", props);
+            smoothness = FindProperty("_Smoothness", props);
+            maskMap = FindProperty(kMaskMap, props);
+            specularOcclusionMap = FindProperty(kspecularOcclusionMap, props);
+            normalMap = FindProperty(kNormalMap, props);
+            heightMap = FindProperty(kHeightMap, props);
+            heightScale = FindProperty("_HeightScale", props);
+            heightBias = FindProperty("_HeightBias", props);
+            tangentMap = FindProperty("_TangentMap", props);
+            anisotropy = FindProperty("_Anisotropy", props);
+            anisotropyMap = FindProperty("_AnisotropyMap", props);
+            emissiveColor = FindProperty("_EmissiveColor", props);
+            emissiveColorMap = FindProperty(kEmissiveColorMap, props);
+            emissiveIntensity = FindProperty("_EmissiveIntensity", props);
+            detailMap = FindProperty(kDetailMap, props);
+            detailMask = FindProperty(kDetailMask, props);
+            detailAlbedoScale = FindProperty(kDetailAlbedoScale, props);
+            detailNormalScale = FindProperty(kDetailNormalScale, props);
+            detailSmoothnessScale = FindProperty(kDetailSmoothnessScale, props);
+            detailHeightScale = FindProperty(kDetailHeightScale, props);
+            detailAOScale = FindProperty(kDetailAOScale, props);
+        }
+
+        override protected void ShaderInputOptionsGUI()
+        {
+            EditorGUI.indentLevel++;
+            GUILayout.Label(Styles.InputsOptionsText, EditorStyles.boldLabel);
+            m_MaterialEditor.ShaderProperty(smoothnessMapChannel, Styles.smoothnessMapChannelText.text);
+            m_MaterialEditor.ShaderProperty(emissiveColorMode, Styles.emissiveColorModeText.text);
+            m_MaterialEditor.ShaderProperty(normalMapSpace, Styles.normalMapSpaceText.text);
+            m_MaterialEditor.ShaderProperty(heightMapMode, Styles.heightMapModeText.text);
+            m_MaterialEditor.ShaderProperty(detailMapMode, Styles.detailMapModeText.text);
+            EditorGUI.indentLevel--;
+        }
+
+        override protected void ShaderInputGUI()
+        {
+            EditorGUI.indentLevel++;
+            bool smoothnessInAlbedoAlpha = (SmoothnessMapChannel)smoothnessMapChannel.floatValue == SmoothnessMapChannel.AlbedoAlpha;
+            bool useEmissiveMask = (EmissiveColorMode)emissiveColorMode.floatValue == EmissiveColorMode.UseEmissiveMask;
+            bool useDetailMapWithNormal = (DetailMapMode)detailMapMode.floatValue == DetailMapMode.DetailWithNormal;
+
+            GUILayout.Label(Styles.InputsText, EditorStyles.boldLabel);
+            m_MaterialEditor.TexturePropertySingleLine(smoothnessInAlbedoAlpha ? Styles.baseColorSmoothnessText : Styles.baseColorText, baseColorMap, baseColor);
+            m_MaterialEditor.ShaderProperty(metallic, Styles.metallicText);
+            m_MaterialEditor.ShaderProperty(smoothness, Styles.smoothnessText);
+
+            if (smoothnessInAlbedoAlpha && useEmissiveMask)
+                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapEText, maskMap);
+            else if (smoothnessInAlbedoAlpha && !useEmissiveMask)
+                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapText, maskMap);
+            else if (!smoothnessInAlbedoAlpha && useEmissiveMask)
+                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapESText, maskMap);
+            else if (!smoothnessInAlbedoAlpha && !useEmissiveMask)
+                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapSText, maskMap);
+
+            m_MaterialEditor.TexturePropertySingleLine(Styles.specularOcclusionMapText, specularOcclusionMap);
+
+            m_MaterialEditor.TexturePropertySingleLine(Styles.normalMapText, normalMap);
+
+            m_MaterialEditor.TexturePropertySingleLine(Styles.heightMapText, heightMap, heightScale, heightBias);
+
+            m_MaterialEditor.TexturePropertySingleLine(Styles.tangentMapText, tangentMap);
+
+            m_MaterialEditor.ShaderProperty(anisotropy, Styles.anisotropyText);
+            
+            m_MaterialEditor.TexturePropertySingleLine(Styles.anisotropyMapText, anisotropyMap);
+
+            EditorGUILayout.Space();
+            GUILayout.Label(Styles.detailText, EditorStyles.boldLabel);
+
+            m_MaterialEditor.TexturePropertySingleLine(Styles.detailMaskText, detailMask); 
+            m_MaterialEditor.ShaderProperty(UVDetail, Styles.uvSetLabel.text);          
+
+            if (useDetailMapWithNormal)
+            {
+                m_MaterialEditor.TexturePropertySingleLine(Styles.detailMapNormalText, detailMap);
+            }
+            else
+            {
+                m_MaterialEditor.TexturePropertySingleLine(Styles.detailMapAOHeightText, detailMap);
+            }
+            m_MaterialEditor.TextureScaleOffsetProperty(detailMap);
+            EditorGUI.indentLevel++;
+            m_MaterialEditor.ShaderProperty(detailAlbedoScale, Styles.detailAlbedoScaleText);
+            m_MaterialEditor.ShaderProperty(detailNormalScale, Styles.detailNormalScaleText);
+            m_MaterialEditor.ShaderProperty(detailSmoothnessScale, Styles.detailSmoothnessScaleText);
+            m_MaterialEditor.ShaderProperty(detailHeightScale, Styles.detailHeightScaleText);
+            m_MaterialEditor.ShaderProperty(detailAOScale, Styles.detailAOScaleText);
+            EditorGUI.indentLevel--;
+
+            EditorGUILayout.Space();
+            GUILayout.Label(Styles.lightingText, EditorStyles.boldLabel);
+
+            if (!useEmissiveMask)
+            {
+                m_MaterialEditor.TexturePropertySingleLine(Styles.emissiveText, emissiveColorMap, emissiveColor);
+            }
+            m_MaterialEditor.ShaderProperty(emissiveIntensity, Styles.emissiveIntensityText);
+            m_MaterialEditor.LightmapEmissionProperty(MaterialEditor.kMiniTextureFieldLabelIndentLevel + 1);
+
+            EditorGUI.indentLevel--;
+        }
+
+        // TODO: try to setup minimun value to fall back to standard shaders and reverse
+        public override void AssignNewShaderToMaterial(Material material, Shader oldShader, Shader newShader)
+        {
+            base.AssignNewShaderToMaterial(material, oldShader, newShader);
+        }
+
+        protected virtual void SetupKeywordsForInputMaps(Material material)
+        {
+            SetKeyword(material, "_NORMALMAP", material.GetTexture(kNormalMap) || material.GetTexture(kDetailMap)); // With details map, we always use a normal map and Unity provide a default (0, 0, 1) normal map for ir
+            SetKeyword(material, "_MASKMAP", material.GetTexture(kMaskMap));
+            SetKeyword(material, "_SPECULAROCCLUSIONMAP", material.GetTexture(kspecularOcclusionMap));
+            SetKeyword(material, "_EMISSIVE_COLOR_MAP", material.GetTexture(kEmissiveColorMap));
+            SetKeyword(material, "_HEIGHTMAP", material.GetTexture(kHeightMap));
+            SetKeyword(material, "_TANGENTMAP", material.GetTexture(kTangentMap));
+            SetKeyword(material, "_ANISOTROPYMAP", material.GetTexture(kAnisotropyMap));
+            SetKeyword(material, "_DETAIL_MAP", material.GetTexture(kDetailMap));
+        }
+
+        protected virtual void SetupEmissionGIFlags(Material material)
+        {
+            // Setup lightmap emissive flags
+
+            MaterialGlobalIlluminationFlags flags = material.globalIlluminationFlags;
+            if ((flags & (MaterialGlobalIlluminationFlags.BakedEmissive | MaterialGlobalIlluminationFlags.RealtimeEmissive)) != 0)
+            {
+                if (ShouldEmissionBeEnabled(material))
+                    flags &= ~MaterialGlobalIlluminationFlags.EmissiveIsBlack;
+                else
+                    flags |= MaterialGlobalIlluminationFlags.EmissiveIsBlack;
+
+                material.globalIlluminationFlags = flags;
+            }
+        }
+
+        override protected void SetupInputMaterial(Material material)
+        {
+            // Note: keywords must be based on Material value not on MaterialProperty due to multi-edit & material animation
+            // (MaterialProperty value might come from renderer material property block)
             SetKeyword(material, "_NORMALMAP_TANGENT_SPACE", (NormalMapSpace)material.GetFloat(kNormalMapSpace) == NormalMapSpace.TangentSpace);
             SetKeyword(material, "_SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A", ((SmoothnessMapChannel)material.GetFloat(kSmoothnessTextureChannelProp)) == SmoothnessMapChannel.AlbedoAlpha);
             SetKeyword(material, "_EMISSIVE_COLOR", ((EmissiveColorMode)material.GetFloat(kEmissiveColorMode)) == EmissiveColorMode.UseEmissiveColor);
@@ -539,14 +573,6 @@ namespace UnityEditor
             */
 
             return true;
-        }
-
-        protected void SetKeyword(Material m, string keyword, bool state)
-        {
-            if (state)
-                m.EnableKeyword(keyword);
-            else
-                m.DisableKeyword(keyword);
         }
     }
 } // namespace UnityEditor


### PR DESCRIPTION
Declare common material option (which will be common for all generated shader from MaterialGraph) in BaseLitUI, LitUI is an implementation of BaseLitUI abstract and add the specific material options (color texture, detail map, emissive map, etc.).

_This PR will help the next merges for MaterialGraph integration._