### PR TITLE
Implement a hotfix for the sky

### DIFF
--- a/Assets/ScriptableRenderLoop/HDRenderPipeline/Sky/ProceduralSky/ProceduralSkyRenderer.cs
+++ b/Assets/ScriptableRenderLoop/HDRenderPipeline/Sky/ProceduralSky/ProceduralSkyRenderer.cs
@@ -156,6 +156,12 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (builtinParams.depthBuffer != BuiltinSkyParameters.invalidRTI)
             {
                 cmd.SetGlobalTexture("_CameraDepthTexture", builtinParams.depthBuffer);
+                cmd.SetGlobalFloat("_DisableSkyOcclusionTest", 0.0f);
+            }
+            else
+            {
+                // For some reason, disabling the 'PERFORM_SKY_OCCLUSION_TEST' keyword has no effect.
+                cmd.SetGlobalFloat("_DisableSkyOcclusionTest", 1.0f);
             }
             cmd.DrawMesh(builtinParams.skyMesh, Matrix4x4.identity, m_ProceduralSkyMaterial);
             builtinParams.renderContext.ExecuteCommandBuffer(cmd);

--- a/Assets/ScriptableRenderLoop/HDRenderPipeline/Sky/ProceduralSky/Resources/SkyProcedural.shader
+++ b/Assets/ScriptableRenderLoop/HDRenderPipeline/Sky/ProceduralSky/Resources/SkyProcedural.shader
@@ -36,6 +36,8 @@ Shader "Hidden/HDRenderPipeline/Sky/SkyProcedural"
             float4x4 _InvViewProjMatrix;
             float4x4 _ViewProjMatrix;
 
+            float _DisableSkyOcclusionTest;
+
             #define IS_RENDERING_SKY
             #include "AtmosphericScattering.hlsl"
 
@@ -88,6 +90,12 @@ Shader "Hidden/HDRenderPipeline/Sky/SkyProcedural"
                     float depthRaw     = skyDepth;
                     float skyTexWeight = 1.0;
                 #endif
+
+                if (_DisableSkyOcclusionTest != 0.0)
+                {
+                    depthRaw     = skyDepth;
+                    skyTexWeight = 1.0;
+                }
 
                 UpdatePositionInput(depthRaw, _InvViewProjMatrix, _ViewProjMatrix, posInput);
 


### PR DESCRIPTION
For some reason, disabling the 'PERFORM_SKY_OCCLUSION_TEST' keyword has no effect.