### PR TITLE
Fix single pass loop on PS4

### DIFF
--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -437,16 +437,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             cmd.SetGlobalMatrix("_InvProjMatrix",     hdCamera.invProjectionMatrix);
             cmd.SetGlobalVector("_InvProjParam",      hdCamera.invProjectionParam);
 
-            // TODO: cmd.SetGlobalInt() does not exist, so we are forced to use Shader.SetGlobalInt() instead.
-
+            // TODO: setting the Sky Settings to 'None' appears to do nothing (so no invalidation happens).
             if (m_SkyManager.IsSkyValid())
             {
+                Shader.EnableKeyword("SKY_LIGHTING");
                 m_SkyManager.SetGlobalSkyTexture();
-                Shader.SetGlobalInt("_EnvLightSkyEnabled", 1);
             }
             else
             {
-                Shader.SetGlobalInt("_EnvLightSkyEnabled", 0);
+                Shader.DisableKeyword("SKY_LIGHTING");
             }
 
             // Broadcast SSS parameters to all shaders.

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Resources/Deferred.shader
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Resources/Deferred.shader
@@ -48,7 +48,7 @@ Shader "Hidden/HDRenderPipeline/Deferred"
             #pragma shader_feature _ SSS_PRE_SCATTER_TEXTURING SSS_POST_SCATTER_TEXTURING
          // #endif
 
-            #pragma shader_feature SKY_LIGHTING
+            #pragma multi_compile _ SKY_LIGHTING
 
             #pragma multi_compile _ LIGHTING_DEBUG
 

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Resources/Deferred.shader
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Resources/Deferred.shader
@@ -48,6 +48,8 @@ Shader "Hidden/HDRenderPipeline/Deferred"
             #pragma shader_feature _ SSS_PRE_SCATTER_TEXTURING SSS_POST_SCATTER_TEXTURING
          // #endif
 
+            #pragma shader_feature SKY_LIGHTING
+
             #pragma multi_compile _ LIGHTING_DEBUG
 
             //-------------------------------------------------------------------------------------

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -187,6 +187,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             public const int k_MaxCascadeCount = 4; //Should be not less than m_Settings.directionalLightCascadeCount;
 
             // Static keyword is required here else we get a "DestroyBuffer can only be call in main thread"
+            static ComputeBuffer s_LightingSettings = null; // We use a structured buffer instead of a constant buffer due to the delay between setting values via constant and other buffer types on PS4
             static ComputeBuffer s_DirectionalLightDatas = null;
             static ComputeBuffer s_LightDatas = null;
             static ComputeBuffer s_EnvLightDatas = null;
@@ -237,6 +238,31 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             int m_punctualLightCount = 0;
             int m_areaLightCount = 0;
             int m_lightCount = 0;
+
+            // See LightingSettings in TilePass.hlsl.
+            public struct LightingSettings
+            {
+                public uint    directionalLightCount;
+                public uint    punctualLightCount;
+                public uint    areaLightCount;
+                public uint    envLightCount;
+                public uint    numTileFtplX;
+                public uint    numTileFtplY;
+                // public uint    numTileClusteredX;
+                // public uint    numTileClusteredY;
+                // public uint    isLogBaseBufferEnabled;
+                // public uint    log2NumClusters;
+                // public float   clusterScale;
+                // public float   clusterBase;
+                // public float   nearPlane;
+                // public float   farPlane;
+                public Vector4 dirShadowSplitSpheres0;
+                public Vector4 dirShadowSplitSpheres1;
+                public Vector4 dirShadowSplitSpheres2;
+                public Vector4 dirShadowSplitSpheres3;
+            };
+
+            LightingSettings[] m_LightingSettings = new LightingSettings[1];
 
             private ComputeShader buildScreenAABBShader { get { return m_PassResources.buildScreenAABBShader; } }
             private ComputeShader buildPerTileLightListShader { get { return m_PassResources.buildPerTileLightListShader; } }
@@ -372,6 +398,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 m_lightList = new LightList();
                 m_lightList.Allocate();
 
+                s_LightingSettings = new ComputeBuffer(1, System.Runtime.InteropServices.Marshal.SizeOf(typeof(LightingSettings)));
                 s_DirectionalLightDatas = new ComputeBuffer(k_MaxDirectionalLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(DirectionalLightData)));
                 s_LightDatas = new ComputeBuffer(k_MaxPunctualLightsOnScreen + k_MaxAreaLightsOnSCreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(LightData)));
                 s_EnvLightDatas = new ComputeBuffer(k_MaxEnvLightsOnScreen, System.Runtime.InteropServices.Marshal.SizeOf(typeof(EnvLightData)));
@@ -516,6 +543,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 UnityEditor.SceneView.onSceneGUIDelegate -= OnSceneGUI;
 #endif
 
+                Utilities.SafeRelease(s_LightingSettings);
                 Utilities.SafeRelease(s_DirectionalLightDatas);
                 Utilities.SafeRelease(s_LightDatas);
                 Utilities.SafeRelease(s_EnvLightDatas);
@@ -1568,18 +1596,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 SetGlobalTexture("_CookieCubeTextures", m_CubeCookieTexArray.GetTexCache());
                 SetGlobalTexture("_EnvTextures", m_CubeReflTexArray.GetTexCache());
 
+                SetGlobalBuffer("_LightingSettings", s_LightingSettings);
                 SetGlobalBuffer("_DirectionalLightDatas", s_DirectionalLightDatas);
-                SetGlobalInt("_DirectionalLightCount", m_lightList.directionalLights.Count);
                 SetGlobalBuffer("_LightDatas", s_LightDatas);
-                SetGlobalInt("_PunctualLightCount", m_punctualLightCount);
-                SetGlobalInt("_AreaLightCount", m_areaLightCount);
                 SetGlobalBuffer("_EnvLightDatas", s_EnvLightDatas);
-                SetGlobalInt("_EnvLightCount", m_lightList.envLights.Count);
                 SetGlobalBuffer("_ShadowDatas", s_shadowDatas);
-                SetGlobalVectorArray("_DirShadowSplitSpheres", m_lightList.directionalShadowSplitSphereSqr);
-
-                SetGlobalInt("_NumTileFtplX", GetNumTileFtplX(camera));
-                SetGlobalInt("_NumTileFtplY", GetNumTileFtplY(camera));
 
                 SetGlobalInt("_NumTileClusteredX", GetNumTileClusteredX(camera));
                 SetGlobalInt("_NumTileClusteredY", GetNumTileClusteredY(camera));
@@ -1609,7 +1630,26 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 var cmd = new CommandBuffer { name = "Push Global Parameters" };
 
+                m_LightingSettings[0].directionalLightCount  = (uint)m_lightList.directionalLights.Count;
+                m_LightingSettings[0].punctualLightCount     = (uint)m_punctualLightCount;
+                m_LightingSettings[0].areaLightCount         = (uint)m_areaLightCount;
+                m_LightingSettings[0].envLightCount          = (uint)m_lightList.envLights.Count;
+                m_LightingSettings[0].numTileFtplX           = (uint)GetNumTileFtplX(camera);
+                m_LightingSettings[0].numTileFtplY           = (uint)GetNumTileFtplY(camera);
+                // m_LightingSettings[0].numTileClusteredX      = (uint)GetNumTileClusteredX(camera);
+                // m_LightingSettings[0].numTileClusteredY      = (uint)GetNumTileClusteredY(camera);
+                // m_LightingSettings[0].isLogBaseBufferEnabled = (uint)(k_UseDepthBuffer ? 1 : 0);
+                // m_LightingSettings[0].log2NumClusters        = k_Log2NumClusters;
+                // m_LightingSettings[0].clusterBase            = k_ClustLogBase;
+                // m_LightingSettings[0].clusterScale           = m_ClustScale;
+                // m_LightingSettings[0].nearPlane              = camera.nearClipPlane;
+                // m_LightingSettings[0].farPlane               = camera.farClipPlane;
+                m_LightingSettings[0].dirShadowSplitSpheres0 = m_lightList.directionalShadowSplitSphereSqr[0];
+                m_LightingSettings[0].dirShadowSplitSpheres1 = m_lightList.directionalShadowSplitSphereSqr[1];
+                m_LightingSettings[0].dirShadowSplitSpheres2 = m_lightList.directionalShadowSplitSphereSqr[2];
+                m_LightingSettings[0].dirShadowSplitSpheres3 = m_lightList.directionalShadowSplitSphereSqr[3];
 
+                s_LightingSettings.SetData(m_LightingSettings);
                 s_DirectionalLightDatas.SetData(m_lightList.directionalLights.ToArray());
                 s_LightDatas.SetData(m_lightList.lights.ToArray());
                 s_EnvLightDatas.SetData(m_lightList.envLights.ToArray());
@@ -1750,7 +1790,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                             Utilities.SetMatrixCS(cmd, shadeOpaqueShader, "_InvViewProjMatrix", invViewProjection);
                             Utilities.SetMatrixCS(cmd, shadeOpaqueShader, "_ViewProjMatrix", viewProjection);
-                            Utilities.SetMatrixCS(cmd, shadeOpaqueShader, "g_mInvScrProjection", Shader.GetGlobalMatrix("g_mInvScrProjection"));
                             cmd.SetComputeVectorParam(shadeOpaqueShader, "_ScreenSize", Shader.GetGlobalVector("_ScreenSize"));
                             cmd.SetComputeIntParam(shadeOpaqueShader, "_UseTileLightList", Shader.GetGlobalInt("_UseTileLightList"));
 
@@ -1763,7 +1802,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                             cmd.SetComputeVectorParam(shadeOpaqueShader, "_ScreenParams", Shader.GetGlobalVector("_ScreenParams"));
                             cmd.SetComputeVectorParam(shadeOpaqueShader, "_ZBufferParams", Shader.GetGlobalVector("_ZBufferParams"));
                             cmd.SetComputeVectorParam(shadeOpaqueShader, "unity_OrthoParams", Shader.GetGlobalVector("unity_OrthoParams"));
-                            cmd.SetComputeIntParam(shadeOpaqueShader, "_EnvLightSkyEnabled", Shader.GetGlobalInt("_EnvLightSkyEnabled"));
 
                             Texture skyTexture = Shader.GetGlobalTexture("_SkyTexture");
                             Texture IESArrayTexture = Shader.GetGlobalTexture("_IESArray");

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
@@ -32,7 +32,7 @@ void ApplyDebug(LightLoopContext lightLoopContext, float3 positionWS, inout floa
         float shadow = GetDirectionalShadowAttenuation(lightLoopContext, positionWS, 0, float3(0.0, 0.0, 0.0), float2(0.0, 0.0));
 #endif
 
-        int shadowSplitIndex = GetSplitSphereIndexForDirshadows(positionWS, _DirShadowSplitSpheres);
+        int shadowSplitIndex = GetSplitSphereIndexForDirshadows(positionWS, _LightingSettings[0].dirShadowSplitSpheres);
         if (shadowSplitIndex == -1)
             diffuseLighting = float3(0.0, 0.0, 0.0);
         else
@@ -50,7 +50,7 @@ void ApplyDebug(LightLoopContext lightLoopContext, float3 positionWS, inout floa
 int GetTileOffset(PositionInputs posInput, uint lightCategory)
 {
     uint2 tileIndex = posInput.unPositionSS / TILE_SIZE_FPTL;
-    return (tileIndex.y + lightCategory * _NumTileFtplY) * _NumTileFtplX + tileIndex.x;
+    return (tileIndex.y + lightCategory * _LightingSettings[0].numTileFtplY) * _LightingSettings[0].numTileFtplX + tileIndex.x;
 }
 
 void GetCountAndStartTile(PositionInputs posInput, uint lightCategory, out uint start, out uint lightCount)
@@ -148,7 +148,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData prelightData, BS
     uint i = 0; // Declare once to avoid the D3D11 compiler warning.
 
 #ifdef PROCESS_DIRECTIONAL_LIGHT
-    for (i = 0; i < _DirectionalLightCount; ++i)
+    for (i = 0; i < _LightingSettings[0].directionalLightCount; ++i)
     {
         float3 localDiffuseLighting, localSpecularLighting;
 
@@ -212,7 +212,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData prelightData, BS
     float3 iblSpecularLighting = float3(0.0, 0.0, 0.0);
 
     // Only apply sky IBL if the sky texture is available.
-    if (_EnvLightSkyEnabled)
+#ifdef SKY_LIGHTING
     {
         float3 localDiffuseLighting, localSpecularLighting;
         float2 weight;
@@ -223,6 +223,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData prelightData, BS
         iblDiffuseLighting = lerp(iblDiffuseLighting, localDiffuseLighting, weight.x); // Should be remove by the compiler if it is smart as all is constant 0
         iblSpecularLighting = lerp(iblSpecularLighting, localSpecularLighting, weight.y);
     }
+#endif
 
     uint envLightStart;
     uint envLightCount;
@@ -272,7 +273,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData prelightData, BS
 
     uint i = 0; // Declare once to avoid the D3D11 compiler warning.
 
-    for (i = 0; i < _DirectionalLightCount; ++i)
+    for (i = 0; i < _LightingSettings[0].directionalLightCount; ++i)
     {
         float3 localDiffuseLighting, localSpecularLighting;
 
@@ -283,7 +284,8 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData prelightData, BS
         specularLighting += localSpecularLighting;
     }
 
-    for (i = 0; i < _PunctualLightCount; ++i)
+
+    for (i = 0; i < _LightingSettings[0].punctualLightCount; ++i)
     {
         float3 localDiffuseLighting, localSpecularLighting;
 
@@ -295,7 +297,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData prelightData, BS
     }
 
     // Area are store with punctual, just offset the index
-    for (i = _PunctualLightCount; i < _AreaLightCount + _PunctualLightCount; ++i)
+    for (i = _LightingSettings[0].punctualLightCount; i < _LightingSettings[0].punctualLightCount + _LightingSettings[0].areaLightCount; ++i)
     {
         float3 localDiffuseLighting, localSpecularLighting;
 
@@ -320,7 +322,7 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData prelightData, BS
     float3 iblSpecularLighting = float3(0.0, 0.0, 0.0);
 
     // Only apply sky IBL if the sky texture is available.
-    if (_EnvLightSkyEnabled)
+#ifdef SKY_LIGHTING
     {
         float3 localDiffuseLighting, localSpecularLighting;
         float2 weight;
@@ -331,8 +333,9 @@ void LightLoop( float3 V, PositionInputs posInput, PreLightData prelightData, BS
         iblDiffuseLighting = lerp(iblDiffuseLighting, localDiffuseLighting, weight.x); // Should be remove by the compiler if it is smart as all is constant 0
         iblSpecularLighting = lerp(iblSpecularLighting, localSpecularLighting, weight.y);
     }
+#endif
 
-    for (i = 0; i < _EnvLightCount; ++i)
+    for (i = 0; i < _LightingSettings[0].envLightCount; ++i)
     {
         float3 localDiffuseLighting, localSpecularLighting;
         float2 weight;


### PR DESCRIPTION
#1: Fix the detection of orthographic projection, and therefore the viewing direction when looking straight down.

#2: Fix flickering issues on PS4 for the single pass loop (+ initial fixes for FPTL).

Flickering is caused by the delay between values in the constant buffer (globals) and values in structured buffers becoming visible in the Deferred shader. It appears that the update latency (the number of frames between setting the value in C# and being able to access it in a shader) varies depending on the type of buffer. Therefore, moving globals into a structured buffer provides a workaround for the single pass loop.

Doing the same for FPTL does not appear to be sufficient. Could be that the additional compute pass introduces extra frame(s) of latency, or that globals from ShaderVariables.hlsl need to be moved as well.

Globals from Clustered appear to be set once for multiple shaders, which makes implementing a similar workarond even more complicated.