### PR TITLE
Small refactor of ComputeBuffer handling for lighting

### DIFF
--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -486,9 +486,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             renderContext.ExecuteCommandBuffer(cmd);
             cmd.Dispose();
-
-            if (m_LightLoop != null)
-                m_LightLoop.PushGlobalParams(hdCamera.camera, renderContext);
         }
 
         bool NeedDepthBufferCopy()

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/LightLoop.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/LightLoop.cs
@@ -26,8 +26,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // TODO: this should not be part of the interface but for now make something working
         public virtual void BuildGPULightLists(Camera camera, ScriptableRenderContext loop, RenderTargetIdentifier cameraDepthBufferRT) { }
 
-        public virtual void PushGlobalParams(Camera camera, ScriptableRenderContext loop) {}
-
         public virtual void RenderDeferredLighting(HDCamera hdCamera, ScriptableRenderContext renderContext,
                                                    LightingDebugSettings lightDebugParameters,
                                                    RenderTargetIdentifier[] colorBuffers, RenderTargetIdentifier depthStencilBuffer, RenderTargetIdentifier depthStencilTexture,

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.hlsl
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.hlsl
@@ -1,4 +1,4 @@
-#if defined (LIGHTLOOP_TILE_DIRECT) || defined(LIGHTLOOP_TILE_ALL)
+﻿#if defined (LIGHTLOOP_TILE_DIRECT) || defined(LIGHTLOOP_TILE_ALL)
 #define PROCESS_DIRECTIONAL_LIGHT
 #define PROCESS_PUNCTUAL_LIGHT
 #define PROCESS_AREA_LIGHT
@@ -48,10 +48,10 @@ StructuredBuffer<uint> g_vLayeredOffsetsBuffer;		// don't support Buffer yet in 
 StructuredBuffer<float> g_logBaseBuffer;			// don't support Buffer yet in unity
 //#endif
 
-StructuredBuffer<DirectionalLightData>  _DirectionalLightDatas;
-StructuredBuffer<LightData>             _LightDatas;
-StructuredBuffer<EnvLightData>          _EnvLightDatas;
-StructuredBuffer<ShadowData>            _ShadowDatas;
+StructuredBuffer<DirectionalLightData> _DirectionalLightDatas;
+StructuredBuffer<LightData>            _LightDatas;
+StructuredBuffer<EnvLightData>         _EnvLightDatas;
+StructuredBuffer<ShadowData>           _ShadowDatas;
 
 // Use texture atlas for shadow map
 //TEXTURE2D(_ShadowAtlas);


### PR DESCRIPTION
- PushGlobalXXX methods in TilePass.cs now use command buffer (all but Int version which does not exist yet)
- Moved setup of various compute buffers for lighting so that they are compliant with double buffering when it's in.