### PR TITLE
Fix specular artifacts for (NdotV < 0)

### DIFF
--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
@@ -50,9 +50,10 @@ TEXTURE2D_ARRAY(_LtcData); // We pack the 3 Ltc data inside a texture array
 #define LTC_LUT_OFFSET (0.5 * rcp(LTC_LUT_SIZE))
 
 // SSS parameters
-#define SSS_N_PROFILES      8
-#define SSS_UNIT_CONVERSION (1.0 / 300.0)                  // From 1/3 centimeters to meters
-#define SSS_LOW_THICKNESS   0.002                          // 2 mm
+#define SSS_N_PROFILES        8
+#define SSS_UNIT_CONVERSION   (1.0 / 300.0)                // From 1/3 centimeters to meters
+#define SSS_LOW_THICKNESS     0.005                        // 0.5 cm
+#define CENTIMETERS_TO_METERS (1.0 / 100.0)
 
 uint   _EnableSSS;                                         // Globally toggles subsurface scattering on/off
 uint   _TransmissionFlags;                                 // 1 bit/profile; 0 = inf. thick, 1 = supports transmission
@@ -129,7 +130,7 @@ float3 ComputeTransmittance(float3 halfRcpVariance1, float lerpWeight1,
     // Thickness and SSS radius are decoupled for artists.
     // In theory, we should modify the thickness by the inverse of the radius scale of the profile.
     // thickness /= radiusScale;
-    thickness /= SSS_UNIT_CONVERSION;
+    thickness /= CENTIMETERS_TO_METERS;
 
     float t2 = thickness * thickness;
 
@@ -162,8 +163,8 @@ void FillMaterialIdSSSData(float3 baseColor, int subsurfaceProfile, float subsur
     bsdfData.subsurfaceProfile = subsurfaceProfile;
     // Make the Std. Dev. of 1 correspond to the effective radius of 1 cm (three-sigma rule).
     bsdfData.subsurfaceRadius = SSS_UNIT_CONVERSION * subsurfaceRadius + 0.0001;
-    bsdfData.thickness = SSS_UNIT_CONVERSION * (_ThicknessRemaps[subsurfaceProfile][0] +
-                                                _ThicknessRemaps[subsurfaceProfile][1] * thickness);
+    bsdfData.thickness = CENTIMETERS_TO_METERS * (_ThicknessRemaps[subsurfaceProfile][0] +
+                                                  _ThicknessRemaps[subsurfaceProfile][1] * thickness);
 
     bsdfData.enableTransmission = IsBitSet(_TransmissionFlags, subsurfaceProfile);
     if (bsdfData.enableTransmission)

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/SubsurfaceScatteringProfile.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/SubsurfaceScatteringProfile.cs
@@ -402,10 +402,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         private class Styles
         {
             public readonly GUIContent   sssProfilePreview0        = new GUIContent("Profile Preview");
-            public readonly GUIContent   sssProfilePreview1        = new GUIContent("Shows the fraction of light scattered from the source as radius increases to 1.");
+            public readonly GUIContent   sssProfilePreview1        = new GUIContent("Shows the fraction of light scattered from the source as the radius increases to 1.");
             public readonly GUIContent   sssProfilePreview2        = new GUIContent("Note that the intensity of the region in the center may be clamped.");
             public readonly GUIContent   sssTransmittancePreview0  = new GUIContent("Transmittance Preview");
-            public readonly GUIContent   sssTransmittancePreview1  = new GUIContent("Shows the fraction of light passing through the object as thickness increases to 1.");
+            public readonly GUIContent   sssTransmittancePreview1  = new GUIContent("Shows the fraction of light passing through the object for thickness values from the remap.");
+            public readonly GUIContent   sssTransmittancePreview2  = new GUIContent("Can be thought of as a cross section of a slab of material illuminated by a white light from the left.");
             public readonly GUIContent   sssProfileStdDev1         = new GUIContent("Standard Deviation #1", "Determines the shape of the 1st Gaussian filter. Increases the strength and the radius of the blur of the corresponding color channel.");
             public readonly GUIContent   sssProfileStdDev2         = new GUIContent("Standard Deviation #2", "Determines the shape of the 2nd Gaussian filter. Increases the strength and the radius of the blur of the corresponding color channel.");
             public readonly GUIContent   sssProfileLerpWeight      = new GUIContent("Filter Interpolation", "Controls linear interpolation between the two Gaussian filters.");
@@ -417,8 +418,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             };
             public readonly GUIContent   sssProfileTransmission    = new GUIContent("Enable Transmission", "Toggles simulation of light passing through thin objects. Depends on the thickness of the material.");
             public readonly GUIContent   sssProfileTintColor       = new GUIContent("Transmission Tint Color", "Tints transmitted light.");
-            public readonly GUIContent   sssProfileMinMaxThickness = new GUIContent("Min-Max Thickness", "Shows the values of the thickness remap below.");
-            public readonly GUIContent   sssProfileThicknessRemap  = new GUIContent("Thickness Remap", "Remaps the thickness parameter from [0, 1] to the desired range.");
+            public readonly GUIContent   sssProfileMinMaxThickness = new GUIContent("Min-Max Thickness", "Shows the values of the thickness remap below (in centimeters).");
+            public readonly GUIContent   sssProfileThicknessRemap  = new GUIContent("Thickness Remap", "Remaps the thickness parameter from [0, 1] to the desired range (in centimeters).");
 
             public readonly GUIStyle     centeredMiniBoldLabel     = new GUIStyle(GUI.skin.label);
 
@@ -500,6 +501,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             EditorGUILayout.Space();
             EditorGUILayout.LabelField(styles.sssTransmittancePreview0, styles.centeredMiniBoldLabel);
             EditorGUILayout.LabelField(styles.sssTransmittancePreview1, EditorStyles.centeredGreyMiniLabel);
+            EditorGUILayout.LabelField(styles.sssTransmittancePreview2, EditorStyles.centeredGreyMiniLabel);
             EditorGUILayout.Space();
 
             // Draw the transmittance graph.

--- a/Assets/ScriptableRenderPipeline/ShaderLibrary/AreaLighting.hlsl
+++ b/Assets/ScriptableRenderPipeline/ShaderLibrary/AreaLighting.hlsl
@@ -1,7 +1,8 @@
 #ifndef UNITY_AREA_LIGHTING_INCLUDED
 #define UNITY_AREA_LIGHTING_INCLUDED
 
-#define SPHERE_LIGHT_APPROXIMATION
+#define APPROXIMATE_POLY_LIGHT_AS_SPHERE_LIGHT
+#define APPROXIMATE_SPHERE_LIGHT_NUMERICALLY
 
 // Not normalized by the factor of 1/TWO_PI.
 float3 ComputeEdgeFactor(float3 V1, float3 V2)
@@ -40,102 +41,103 @@ float IntegrateEdge(float3 V1, float3 V2)
 // N.b.: this function accounts for horizon clipping.
 float DiffuseSphereLightIrradiance(float sinSqSigma, float cosOmega)
 {
-#if 1 // Use a numerical fit for the sphere light approximation found in Mathematica.
+#ifdef APPROXIMATE_SPHERE_LIGHT_NUMERICALLY
     float x = sinSqSigma;
     float y = cosOmega;
 
-    // For most of the domain, the absolute error is pretty low, under 0.005.
-    // You can use the following Mathematica code to reproduce our results:
-    // t = Flatten[Table[{x, y, f[x, y]}, {x, 0, 0.999999, 0.001}, {y, -0.999999, 0.999999, 0.002}], 1]
-    // m = NonlinearModelFit[t, x * (y + e) * (0.5 + (y - e) * (a + b * x + c * x^2 + d * x^3)), {a, b, c, d, e}, {x, y}]
-    return saturate(x * (0.9245867471551246 + y) * (0.5 + (-0.9245867471551246 + y) * (0.5359050373687144 + x * (-1.0054221851257754 + x * (1.8199061187417047 - x * 1.3172081704209504)))));
+    #if 1
+        // Use a numerical fit found in Mathematica.
+        // For most of the domain, the absolute error is fairly low, under 0.005.
+        // You can use the following Mathematica code to reproduce our results:
+        // t = Flatten[Table[{x, y, f[x, y]}, {x, 0, 0.999999, 0.001}, {y, -0.999999, 0.999999, 0.002}], 1]
+        // m = NonlinearModelFit[t, x * (y + e) * (0.5 + (y - e) * (a + b * x + c * x^2 + d * x^3)), {a, b, c, d, e}, {x, y}]
+        return saturate(x * (0.9245867471551246 + y) * (0.5 + (-0.9245867471551246 + y) * (0.5359050373687144 + x * (-1.0054221851257754 + x * (1.8199061187417047 - x * 1.3172081704209504)))));
+    #else
+        // Another fit found with Mathematica. The absolute error is larger (around 0.02 on average), but the function is very smooth.
+        // You can use the following Mathematica code to reproduce our results:
+        // t = Flatten[Table[{x, y, f[x, y]}, {x, 0, 0.999999, 0.001}, {y, -0.999999, 0.999999, 0.002}], 1]
+        // m = NonlinearModelFit[t, 1 - (1 - x)^(a * (y + 1) + b * (y + 1)^2 + c * (y + 1)^3 + d * (y + 1)^4)}, {a, b, c, d}, {x, y}]
+        float p = saturate(0.14506085844485772 + y * (0.2858221675641456 + y * (0.23405929637528905 + y * (0.20682928702038633 + y * 0.1135312997643852))));
+        return saturate(1 - pow(1 - x, p));
+    #endif
 #else
-    float x = sinSqSigma;
-    float y = cosOmega;
+    #if 0 // Ref: Area Light Sources for Real-Time Graphics, page 4 (1996).
+        float sinSqOmega = saturate(1 - cosOmega * cosOmega);
+        float cosSqSigma = saturate(1 - sinSqSigma);
+        float sinSqGamma = saturate(cosSqSigma / sinSqOmega);
+        float cosSqGamma = saturate(1 - sinSqGamma);
 
-    // Another fit found with Mathematica. The error is larger (around 0.02 on average), but the function is very smooth.
-    // You can use the following Mathematica code to reproduce our results:
-    // t = Flatten[Table[{x, y, f[x, y]}, {x, 0, 0.999999, 0.001}, {y, -0.999999, 0.999999, 0.002}], 1]
-    // m = NonlinearModelFit[t, 1 - (1 - x)^(a * (y + 1) + b * (y + 1)^2 + c * (y + 1)^3 + d * (y + 1)^4)}, {a, b, c, d}, {x, y}]
-    float p = saturate(0.14506085844485772 + y * (0.2858221675641456 + y * (0.23405929637528905 + y * (0.20682928702038633 + y * 0.1135312997643852))));
-    return saturate(1 - pow(1 - x, p));
-#endif
-#if 0 // Ref: Area Light Sources for Real-Time Graphics, page 4 (1996).
-    float sinSqOmega = saturate(1 - cosOmega * cosOmega);
-    float cosSqSigma = saturate(1 - sinSqSigma);
-    float sinSqGamma = saturate(cosSqSigma / sinSqOmega);
-    float cosSqGamma = saturate(1 - sinSqGamma);
+        float sinSigma = sqrt(sinSqSigma);
+        float sinGamma = sqrt(sinSqGamma);
+        float cosGamma = sqrt(cosSqGamma);
 
-    float sinSigma = sqrt(sinSqSigma);
-    float sinGamma = sqrt(sinSqGamma);
-    float cosGamma = sqrt(cosSqGamma);
+        float sigma = asin(sinSigma);
+        float omega = acos(cosOmega);
+        float gamma = asin(sinGamma);
 
-    float sigma = asin(sinSigma);
-    float omega = acos(cosOmega);
-    float gamma = asin(sinGamma);
-
-    if (omega >= HALF_PI + sigma)
-    {
-        // Full horizon occlusion (case #4).
-        return 0;
-    }
-
-    float e = sinSqSigma * cosOmega;
-
-    [branch]
-    if (omega < HALF_PI - sigma)
-    {
-        // No horizon occlusion (case #1).
-        return e;
-    }
-    else
-    {
-        float g = (-2 * sqrt(sinSqOmega * cosSqSigma) + sinGamma) * cosGamma + (HALF_PI - gamma);
-        float h = cosOmega * (cosGamma * sqrt(saturate(sinSqSigma - cosSqGamma)) + sinSqSigma * asin(saturate(cosGamma / sinSigma)));
-
-        if (omega < HALF_PI)
+        if (omega >= HALF_PI + sigma)
         {
-            // Partial horizon occlusion (case #2).
-            return saturate(e + INV_PI * (g - h));
+            // Full horizon occlusion (case #4).
+            return 0;
+        }
+
+        float e = sinSqSigma * cosOmega;
+
+        [branch]
+        if (omega < HALF_PI - sigma)
+        {
+            // No horizon occlusion (case #1).
+            return e;
         }
         else
         {
-            // Partial horizon occlusion (case #3).
-            return saturate(INV_PI * (g + h));
+            float g = (-2 * sqrt(sinSqOmega * cosSqSigma) + sinGamma) * cosGamma + (HALF_PI - gamma);
+            float h = cosOmega * (cosGamma * sqrt(saturate(sinSqSigma - cosSqGamma)) + sinSqSigma * asin(saturate(cosGamma / sinSigma)));
+
+            if (omega < HALF_PI)
+            {
+                // Partial horizon occlusion (case #2).
+                return saturate(e + INV_PI * (g - h));
+            }
+            else
+            {
+                // Partial horizon occlusion (case #3).
+                return saturate(INV_PI * (g + h));
+            }
         }
-    }
-#else // Ref: Moving Frostbite to Physically Based Rendering, page 47 (2015, optimized).
-    float cosSqOmega = cosOmega * cosOmega;                     // y^2
+    #else // Ref: Moving Frostbite to Physically Based Rendering, page 47 (2015, optimized).
+        float cosSqOmega = cosOmega * cosOmega;                     // y^2
 
-    [branch]
-    if (cosSqOmega > sinSqSigma)                                // (y^2)>x
-    {
-        return saturate(sinSqSigma * cosOmega);                 // Clip[x*y,{0,1}]
-    }
-    else
-    {
-        float cotSqSigma = rcp(sinSqSigma) - 1;                 // 1/x-1
-        float tanSqSigma = rcp(cotSqSigma);                     // x/(1-x)
-        float sinSqOmega = 1 - cosSqOmega;                      // 1-y^2
+        [branch]
+        if (cosSqOmega > sinSqSigma)                                // (y^2)>x
+        {
+            return saturate(sinSqSigma * cosOmega);                 // Clip[x*y,{0,1}]
+        }
+        else
+        {
+            float cotSqSigma = rcp(sinSqSigma) - 1;                 // 1/x-1
+            float tanSqSigma = rcp(cotSqSigma);                     // x/(1-x)
+            float sinSqOmega = 1 - cosSqOmega;                      // 1-y^2
 
-        float w = sinSqOmega * tanSqSigma;                      // (1-y^2)*(x/(1-x))
-        float x = -cosOmega * rsqrt(w);                         // -y*Sqrt[(1/x-1)/(1-y^2)]
-        float y = sqrt(sinSqOmega * tanSqSigma - cosSqOmega);   // Sqrt[(1-y^2)*(x/(1-x))-y^2]
-        float z = y * cotSqSigma;                               // Sqrt[(1-y^2)*(x/(1-x))-y^2]*(1/x-1)
+            float w = sinSqOmega * tanSqSigma;                      // (1-y^2)*(x/(1-x))
+            float x = -cosOmega * rsqrt(w);                         // -y*Sqrt[(1/x-1)/(1-y^2)]
+            float y = sqrt(sinSqOmega * tanSqSigma - cosSqOmega);   // Sqrt[(1-y^2)*(x/(1-x))-y^2]
+            float z = y * cotSqSigma;                               // Sqrt[(1-y^2)*(x/(1-x))-y^2]*(1/x-1)
 
-        float a = cosOmega * acos(x) - z;                       // y*ArcCos[-y*Sqrt[(1/x-1)/(1-y^2)]]-Sqrt[(1-y^2)*(x/(1-x))-y^2]*(1/x-1)
-        float b = atan(y);                                      // ArcTan[Sqrt[(1-y^2)*(x/(1-x))-y^2]]
+            float a = cosOmega * acos(x) - z;                       // y*ArcCos[-y*Sqrt[(1/x-1)/(1-y^2)]]-Sqrt[(1-y^2)*(x/(1-x))-y^2]*(1/x-1)
+            float b = atan(y);                                      // ArcTan[Sqrt[(1-y^2)*(x/(1-x))-y^2]]
 
-        // Replacing max() with saturate() results in a 12 cycle SGPR forwarding stall on PS4.
-        return max(INV_PI * (a * sinSqSigma + b), 0);           // (a/Pi)*x+(b/Pi)
-    }
+            // Replacing max() with saturate() results in a 12 cycle SGPR forwarding stall on PS4.
+            return max(INV_PI * (a * sinSqSigma + b), 0);           // (a/Pi)*x+(b/Pi)
+        }
+    #endif
 #endif
 }
 
 // Expects non-normalized vertex positions.
 float PolygonIrradiance(float4x3 L)
 {
-#ifdef SPHERE_LIGHT_APPROXIMATION
+#ifdef APPROXIMATE_POLY_LIGHT_AS_SPHERE_LIGHT
     [unroll]
     for (uint i = 0; i < 4; i++)
     {

--- a/Assets/ScriptableRenderPipeline/ShaderLibrary/AreaLighting.hlsl
+++ b/Assets/ScriptableRenderPipeline/ShaderLibrary/AreaLighting.hlsl
@@ -47,8 +47,18 @@ float DiffuseSphereLightIrradiance(float sinSqSigma, float cosOmega)
     // For most of the domain, the absolute error is pretty low, under 0.005.
     // You can use the following Mathematica code to reproduce our results:
     // t = Flatten[Table[{x, y, f[x, y]}, {x, 0, 0.999999, 0.001}, {y, -0.999999, 0.999999, 0.002}], 1]
-    // m = NonlinearModelFit[t, {x * (y + e) * (0.5 + (y - e) * (a + b * x + c * x^2 + d * x^3))}, {a, b, c, d, e}, {x, y}]
+    // m = NonlinearModelFit[t, x * (y + e) * (0.5 + (y - e) * (a + b * x + c * x^2 + d * x^3)), {a, b, c, d, e}, {x, y}]
     return saturate(x * (0.9245867471551246 + y) * (0.5 + (-0.9245867471551246 + y) * (0.5359050373687144 + x * (-1.0054221851257754 + x * (1.8199061187417047 - x * 1.3172081704209504)))));
+#else
+    float x = sinSqSigma;
+    float y = cosOmega;
+
+    // Another fit found with Mathematica. The error is larger (around 0.02 on average), but the function is very smooth.
+    // You can use the following Mathematica code to reproduce our results:
+    // t = Flatten[Table[{x, y, f[x, y]}, {x, 0, 0.999999, 0.001}, {y, -0.999999, 0.999999, 0.002}], 1]
+    // m = NonlinearModelFit[t, 1 - (1 - x)^(a * (y + 1) + b * (y + 1)^2 + c * (y + 1)^3 + d * (y + 1)^4)}, {a, b, c, d}, {x, y}]
+    float p = saturate(0.14506085844485772 + y * (0.2858221675641456 + y * (0.23405929637528905 + y * (0.20682928702038633 + y * 0.1135312997643852))));
+    return saturate(1 - pow(1 - x, p));
 #endif
 #if 0 // Ref: Area Light Sources for Real-Time Graphics, page 4 (1996).
     float sinSqOmega = saturate(1 - cosOmega * cosOmega);

--- a/Assets/ScriptableRenderPipeline/ShaderLibrary/CommonLighting.hlsl
+++ b/Assets/ScriptableRenderPipeline/ShaderLibrary/CommonLighting.hlsl
@@ -188,9 +188,8 @@ float GetHorizonOcclusion(float3 V, float3 normalWS, float3 vertexNormal, float 
 // A way to reduce artifact is to limit NdotV value to not be negative and calculate reflection vector for cubemap with a shifted normal (i.e what depends on the view)
 // This is what provide this function
 // Note: NdotV return by this function is always positive, no need for saturate
-float GetShiftedNdotV(inout float3 N, float3 V)
+float GetShiftedNdotV(inout float3 N, float3 V, float NdotV)
 {
-    float NdotV = dot(N, V);
     const float limit = 0.0001; // Epsilon value that avoid divide by 0 (several BSDF divide by NdotV)
 
     if (NdotV < limit)


### PR DESCRIPTION
Cost: 1 VGPR.
We clamp NdotV between 0.0001 and 1 as we fill the PreLightData.
However, for direct lighting, this changes neither N nor V. Therefore, when we try to use this clamped NdotV value in other geometric calculations, results occasionally make no sense.
Caveat: if (NdotV < 0) and (NdotL -> 0), H may point in the opposite hemisphere from N. Clamped XdotH products appear to take care of this issue.