### PR TITLE
Branch debugmenu2

### DIFF
--- a/Assets/ScriptableRenderPipeline/Core/Debugging/DebugItemUI.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Debugging/DebugItemUI.cs
@@ -141,10 +141,10 @@ namespace UnityEngine.Experimental.Rendering
             string finalValue = new string(valueWithMaxDecimals.ToCharArray(), 0, index + 1);
 
             // Add leading zeros until we reach where the current order is being edited.
-            if(m_CurrentIncrementIndex > 0)
+            if (m_CurrentIncrementIndex > 0)
             {
                 float incrementValue = Mathf.Pow(10.0f, (float)m_CurrentIncrementIndex);
-                if(incrementValue > currentValue)
+                if (incrementValue > currentValue)
                 {
                     float compareValue = currentValue + 1.0f; // Start at 1.0f because we know that we are going to increment by 10 or more
                     while (incrementValue > compareValue)
@@ -156,18 +156,18 @@ namespace UnityEngine.Experimental.Rendering
             }
 
             // When selecting which decimal/order you want to edit, we show brackets around the figure to show the user.
-            if(m_SelectIncrementMode)
+            if (m_SelectIncrementMode)
             {
                 separatorIndex = finalValue.LastIndexOf(separator); // separator may have changed place if we added leading zeros
                 int bracketIndex = separatorIndex - m_CurrentIncrementIndex;
-                if(m_CurrentIncrementIndex >= 0) // Skip separator
+                if (m_CurrentIncrementIndex >= 0) // Skip separator
                     bracketIndex -= 1;
 
                 finalValue = finalValue.Insert(bracketIndex, "[");
                 finalValue = finalValue.Insert(bracketIndex + 2, "]");
             }
 
-            if(isNegative)
+            if (isNegative)
                 finalValue = finalValue.Insert(0, "-");
 
             m_Value.GetComponent<UI.Text>().text = finalValue;
@@ -181,7 +181,7 @@ namespace UnityEngine.Experimental.Rendering
 
         public override void OnIncrement()
         {
-            if(!m_SelectIncrementMode)
+            if (!m_SelectIncrementMode)
             {
                 m_DebugItem.SetValue((float)m_DebugItem.GetValue() + Mathf.Pow(10.0f, (float)m_CurrentIncrementIndex));
             }
@@ -203,7 +203,7 @@ namespace UnityEngine.Experimental.Rendering
             {
                 m_CurrentIncrementIndex += 1; // * 10 (10^m_CurrentIncrementIndex)
             }
-            Update();            
+            Update();
         }
     }
 
@@ -227,10 +227,10 @@ namespace UnityEngine.Experimental.Rendering
             string finalValue = string.Format("{0}", value);
 
             // Add leading zeros until we reach where the current order is being edited.
-            if(m_CurrentIncrementIndex > 0)
+            if (m_CurrentIncrementIndex > 0)
             {
                 int incrementValue = (int)System.Math.Pow(10, m_CurrentIncrementIndex);
-                if(incrementValue > value)
+                if (incrementValue > value)
                 {
                     int compareValue = System.Math.Max(value, 1);
                     while (incrementValue > compareValue)
@@ -242,7 +242,7 @@ namespace UnityEngine.Experimental.Rendering
             }
 
             // When selecting which decimal/order you want to edit, we show brackets around the figure to show the user.
-            if(m_SelectIncrementMode)
+            if (m_SelectIncrementMode)
             {
                 int bracketIndex = finalValue.Length - 1 - m_CurrentIncrementIndex;
 
@@ -250,7 +250,7 @@ namespace UnityEngine.Experimental.Rendering
                 finalValue = finalValue.Insert(bracketIndex + 2, "]");
             }
 
-            if(isNegative)
+            if (isNegative)
                 finalValue = finalValue.Insert(0, "-");
 
             m_Value.GetComponent<UI.Text>().text = finalValue;
@@ -361,7 +361,7 @@ namespace UnityEngine.Experimental.Rendering
 
         private int FindIndexForValue(int value)
         {
-            for(int i = 0 ; i < m_Values.Length ; ++i)
+            for (int i = 0; i < m_Values.Length; ++i)
             {
                 if (m_Values[i] == value)
                     return i;
@@ -372,7 +372,7 @@ namespace UnityEngine.Experimental.Rendering
 
         public override void Update()
         {
-            if(m_CurrentValueIndex != -1)
+            if (m_CurrentValueIndex != -1)
             {
                 m_Value.GetComponent<UI.Text>().text = m_ValueNames[m_CurrentValueIndex].text;
             }

--- a/Assets/ScriptableRenderPipeline/Core/Debugging/DebugMenuManager.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Debugging/DebugMenuManager.cs
@@ -10,9 +10,6 @@ namespace UnityEngine.Experimental.Rendering
     public class DebugMenuManager
     {
         private static DebugMenuManager s_Instance = null;
-        private static string s_MenuStateAssetPath = "Assets/DebugMenuState.asset";
-
-        private DebugMenuState m_DebugMenuState = null;
 
         static public DebugMenuManager instance
         {
@@ -21,7 +18,6 @@ namespace UnityEngine.Experimental.Rendering
                 if (s_Instance == null)
                 {
                     s_Instance = new DebugMenuManager();
-                    s_Instance.Initialize();
                 }
 
                 return s_Instance;
@@ -31,7 +27,6 @@ namespace UnityEngine.Experimental.Rendering
         List<DebugPanel>    m_DebugPanels = new List<DebugPanel>();
         DebugPanel          m_PersistentDebugPanel = null;
         DebugMenuUI         m_DebugMenuUI = null;
-        bool                m_UpdateFromItemStateRequired = false;
 
         public int          panelCount          { get { return m_DebugPanels.Count; } }
         public DebugMenuUI  menuUI              { get { return m_DebugMenuUI; } }
@@ -50,36 +45,6 @@ namespace UnityEngine.Experimental.Rendering
                 go.hideFlags = HideFlags.HideAndDontSave;
                 go.AddComponent<DebugMenuUpdater>();
             }
-        }
-
-        private void Initialize()
-        {
-#if UNITY_EDITOR
-            m_DebugMenuState = UnityEditor.AssetDatabase.LoadAssetAtPath<DebugMenuState>(s_MenuStateAssetPath);
-
-            if (m_DebugMenuState == null)
-            {
-                m_DebugMenuState = ScriptableObject.CreateInstance<DebugMenuState>();
-                UnityEditor.AssetDatabase.CreateAsset(m_DebugMenuState, s_MenuStateAssetPath);
-            }
-#endif
-        }
-
-        public void RequireUpdateFromDebugItemState()
-        {
-            m_UpdateFromItemStateRequired = true;
-        }
-
-        // debug state will be null at runtime.
-        public DebugItemState FindDebugItemState(string itemName, string menuName)
-        {
-            return (m_DebugMenuState != null) ? m_DebugMenuState.FindDebugItemState(itemName, menuName) : null;
-        }
-
-        public void AddDebugItemState(DebugItemState state)
-        {
-            if(m_DebugMenuState != null)
-                m_DebugMenuState.AddDebugItemState(state);
         }
 
         public DebugPanel GetDebugPanel(int index)
@@ -135,12 +100,6 @@ namespace UnityEngine.Experimental.Rendering
         public void Update()
         {
             m_DebugMenuUI.Update();
-
-            if(m_UpdateFromItemStateRequired)
-            {
-                m_UpdateFromItemStateRequired = false;
-                m_DebugMenuState.UpdateAllDebugItems();
-            }
         }
 
         private void AddDebugPanel(DebugPanel panel)

--- a/Assets/ScriptableRenderPipeline/Core/Debugging/Serialization/DebugItemStateColor.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Debugging/Serialization/DebugItemStateColor.cs
@@ -8,3 +8,4 @@ namespace UnityEngine.Experimental.Rendering
     {
     }
 }
+


### PR DESCRIPTION
Moved away all handling of DebugMenuState to DebugMenuEditor. Allowed us to remove all state code from the debug menu logic. Also, the state is no longer stored in a file on disk.