### PR TITLE
Branch commonsettingcleanup

### DIFF
--- a/Assets/ScriptableRenderPipeline/Core/AdditionalLightData.cs
+++ b/Assets/ScriptableRenderPipeline/Core/AdditionalLightData.cs
@@ -63,6 +63,7 @@
         [HideInInspector, SerializeField] private ShadowData    shadowData;
         [HideInInspector, SerializeField] private ShadowData[]  shadowDatas = new ShadowData[0];
 
+        public int cascadeCount { get { return shadowCascadeCount; } }
         public void GetShadowCascades( out int cascadeCount, out float[] cascadeRatios ) { cascadeCount = shadowCascadeCount; cascadeRatios = shadowCascadeRatios; }
         public void GetShadowAlgorithm( out int algorithm, out int variant, out int precision )    { algorithm = shadowAlgorithm; variant = shadowVariant; precision = shadowPrecision; }
         public void SetShadowAlgorithm( int algorithm, int variant, int precision, int format, int[] data )

--- a/Assets/ScriptableRenderPipeline/Core/Debugging/DebugMenuManager.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Debugging/DebugMenuManager.cs
@@ -31,6 +31,9 @@ namespace UnityEngine.Experimental.Rendering
         public int          panelCount          { get { return m_DebugPanels.Count; } }
         public DebugMenuUI  menuUI              { get { return m_DebugMenuUI; } }
 
+        private DebugMenuState m_DebugMenuState = null;
+        private bool m_DebugMenuStateDirty = false;
+
         DebugMenuManager()
         {
             m_PersistentDebugPanel = new DebugPanel<DebugPanelUI>("Persistent");
@@ -99,6 +102,12 @@ namespace UnityEngine.Experimental.Rendering
 
         public void Update()
         {
+            if(m_DebugMenuState != null && m_DebugMenuStateDirty)
+            {
+                m_DebugMenuStateDirty = false;
+                m_DebugMenuState.UpdateAllDebugItems();
+            }
+
             m_DebugMenuUI.Update();
         }
 
@@ -110,11 +119,13 @@ namespace UnityEngine.Experimental.Rendering
 
         public void AddDebugItem<DebugPanelType, DebugItemType>(string name, Func<object> getter, Action<object> setter = null, bool dynamicDisplay = false, DebugItemHandler handler = null) where DebugPanelType : DebugPanel
         {
-            DebugPanelType debugMenu = GetDebugPanel<DebugPanelType>();
-            if (debugMenu != null)
+            DebugPanelType debugPanel = GetDebugPanel<DebugPanelType>();
+            if (debugPanel != null)
             {
-                debugMenu.AddDebugItem<DebugItemType>(name, getter, setter, dynamicDisplay, handler);
+                debugPanel.AddDebugItem<DebugItemType>(name, getter, setter, dynamicDisplay, handler);
             }
+
+            m_DebugMenuStateDirty = true;
         }
 
         public void AddDebugItem<DebugItemType>(string debugPanelName, string name, Func<object> getter, Action<object> setter = null, bool dynamicDisplay = false, DebugItemHandler handler = null)
@@ -131,6 +142,14 @@ namespace UnityEngine.Experimental.Rendering
             {
                 debugPanel.AddDebugItem<DebugItemType>(name, getter, setter, dynamicDisplay, handler);
             }
+
+            m_DebugMenuStateDirty = true;
+        }
+
+        public void SetDebugMenuState(DebugMenuState state)
+        {
+            m_DebugMenuStateDirty = true;
+            m_DebugMenuState = state;
         }
     }
 }

--- a/Assets/ScriptableRenderPipeline/Core/Debugging/DebugMenuState.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Debugging/DebugMenuState.cs
@@ -56,7 +56,8 @@ namespace UnityEngine.Experimental.Rendering
                 }
             }
 
-            m_DebugItem.SetValue(value, false);
+            if(m_DebugItem != null) // Can happen if not all menu are populated yet (depends on call order...)
+                m_DebugItem.SetValue(value, false);
         }
     }
 
@@ -71,13 +72,12 @@ namespace UnityEngine.Experimental.Rendering
 #if UNITY_EDITOR
             UnityEditor.Undo.undoRedoPerformed += OnUndoRedoPerformed;
 #endif
-
             // Populate item states
             DebugMenuManager dmm = DebugMenuManager.instance;
-            for (int panelIdx = 0 ; panelIdx < dmm.panelCount ; ++panelIdx)
+            for (int panelIdx = 0; panelIdx < dmm.panelCount; ++panelIdx)
             {
                 DebugPanel panel = dmm.GetDebugPanel(panelIdx);
-                for(int itemIdx = 0 ; itemIdx < panel.itemCount ; ++itemIdx)
+                for (int itemIdx = 0; itemIdx < panel.itemCount; ++itemIdx)
                 {
                     DebugItem item = panel.GetDebugItem(itemIdx);
                     DebugItemState debugItemState = FindDebugItemState(item);
@@ -92,7 +92,7 @@ namespace UnityEngine.Experimental.Rendering
                 }
             }
 
-            UpdateAllDebugItems();
+            DebugMenuManager.instance.SetDebugMenuState(this);
         }
 
         public void OnDisable()
@@ -135,6 +135,9 @@ namespace UnityEngine.Experimental.Rendering
             {
                 itemState.UpdateDebugItemValue();
             }
+#if UNITY_EDITOR
+            UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+#endif
         }
     }
 }

--- a/Assets/ScriptableRenderPipeline/Core/Debugging/DebugPanel.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Debugging/DebugPanel.cs
@@ -113,6 +113,11 @@ namespace UnityEngine.Experimental.Rendering
         {
             if (handler == null)
                 handler = new DefaultDebugItemHandler();
+
+            DebugItem oldItem = GetDebugItem(itemName);
+            if (oldItem != null)
+                RemoveDebugItem(oldItem);
+
             DebugItem newItem = new DebugItem(itemName, m_Name, typeof(ItemType), getter, setter, dynamicDisplay, handler);
             handler.SetDebugItem(newItem);
             m_Items.Add(newItem);

--- a/Assets/ScriptableRenderPipeline/Core/Debugging/DebugPanelUI.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Debugging/DebugPanelUI.cs
@@ -48,6 +48,9 @@ namespace UnityEngine.Experimental.Rendering
 
         public void RebuildGUI()
         {
+            if (m_Root == null)
+                return;
+
             for (int i = 0; i < m_Root.transform.childCount; ++i)
             {
                 Object.DestroyImmediate(m_Root.transform.GetChild(i).gameObject);

--- a/Assets/ScriptableRenderPipeline/Core/Shadow/Shadow.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Shadow/Shadow.cs
@@ -21,8 +21,6 @@ namespace UnityEngine.Experimental.Rendering
         protected          uint                       m_ActiveEntriesCount;
         protected          FrameId                    m_FrameId;
         protected          string                     m_ShaderKeyword;
-        protected          int                        m_CascadeCount;
-        protected          Vector3                    m_CascadeRatios;
         protected          uint                       m_TexSlot;
         protected          uint                       m_SampSlot;
         protected          uint[]                     m_TmpWidths  = new uint[ShadowmapBase.ShadowRequest.k_MaxFaceCount];
@@ -75,8 +73,6 @@ namespace UnityEngine.Experimental.Rendering
         {
             public BaseInit baseInit;           // the base class's initializer
             public string   shaderKeyword;      // the global shader keyword to use when rendering the shadowmap
-            public int      cascadeCount;       // the number of cascades to use (these are global in ShadowSettings for now for some reason)
-            public Vector3  cascadeRatios;      // cascade split ratios
         }
 
         // UI stuff
@@ -165,8 +161,6 @@ namespace UnityEngine.Experimental.Rendering
         public void Initialize( AtlasInit init )
         {
             m_ShaderKeyword      = init.shaderKeyword;
-            m_CascadeCount       = init.cascadeCount;
-            m_CascadeRatios      = init.cascadeRatios;
         }
 
         override public void ReserveSlots( ShadowContextStorage sc )
@@ -1171,6 +1165,8 @@ namespace UnityEngine.Experimental.Rendering
                 float   distToCam       = (campos - lpos).magnitude;
                 bool    add             = (distToCam < ald.shadowFadeDistance || vl.lightType == LightType.Directional) && m_ShadowSettings.enabled;
 
+                float[] cascadeSplitsDummy = new float[3];
+
                 if( add )
                 {
                     switch( vl.lightType )
@@ -1178,7 +1174,7 @@ namespace UnityEngine.Experimental.Rendering
                         case LightType.Directional:
                             add = --m_MaxShadows[(int)GPUShadowType.Directional, 0] >= 0;
                             shadowType = GPUShadowType.Directional;
-                            facecount = m_ShadowSettings.directionalLightCascadeCount;
+                            ald.GetShadowCascades(out facecount, out cascadeSplitsDummy);
                             break;
                         case LightType.Point:
                             add = --m_MaxShadows[(int)GPUShadowType.Point, 0] >= 0;

--- a/Assets/ScriptableRenderPipeline/Core/Shadow/Shadow.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Shadow/Shadow.cs
@@ -1165,8 +1165,6 @@ namespace UnityEngine.Experimental.Rendering
                 float   distToCam       = (campos - lpos).magnitude;
                 bool    add             = (distToCam < ald.shadowFadeDistance || vl.lightType == LightType.Directional) && m_ShadowSettings.enabled;
 
-                float[] cascadeSplitsDummy = new float[3];
-
                 if( add )
                 {
                     switch( vl.lightType )
@@ -1174,7 +1172,7 @@ namespace UnityEngine.Experimental.Rendering
                         case LightType.Directional:
                             add = --m_MaxShadows[(int)GPUShadowType.Directional, 0] >= 0;
                             shadowType = GPUShadowType.Directional;
-                            ald.GetShadowCascades(out facecount, out cascadeSplitsDummy);
+                            facecount = ald.cascadeCount;
                             break;
                         case LightType.Point:
                             add = --m_MaxShadows[(int)GPUShadowType.Point, 0] >= 0;

--- a/Assets/ScriptableRenderPipeline/Core/Shadow/ShadowBase.cs
+++ b/Assets/ScriptableRenderPipeline/Core/Shadow/ShadowBase.cs
@@ -4,38 +4,26 @@ using System.Collections.Generic;
 
 namespace UnityEngine.Experimental.Rendering
 {
+    // Class holding parameters for the initialization of the Shadow System
+    [Serializable]
+    public class ShadowInitParameters
+    {
+        public const int kDefaultShadowAtlasSize = 4096;
+
+        public int      shadowAtlasWidth = kDefaultShadowAtlasSize;
+        public int      shadowAtlasHeight = kDefaultShadowAtlasSize;
+    }
+
+    // Class used to pass parameters to the shadow system on a per frame basis.
     [Serializable]
     public class ShadowSettings
     {
-        public bool     enabled;
-        public int      shadowAtlasWidth;
-        public int      shadowAtlasHeight;
+        public const float kDefaultMaxShadowDistance = 1000.0f;
+        public const float kDefaultDirectionalNearPlaneOffset = 5.0f;
 
-        public float    maxShadowDistance;
-        public int      directionalLightCascadeCount;
-        public Vector3  directionalLightCascades;
-        public float    directionalLightNearPlaneOffset;
-
-        static ShadowSettings defaultShadowSettings = null;
-
-        public static ShadowSettings Default
-        {
-            get
-            {
-                if (defaultShadowSettings == null)
-                {
-                    defaultShadowSettings = new ShadowSettings();
-                    defaultShadowSettings.enabled = true;
-                    defaultShadowSettings.shadowAtlasHeight = defaultShadowSettings.shadowAtlasWidth = 4096;
-                    defaultShadowSettings.directionalLightCascadeCount = 1;
-                    defaultShadowSettings.directionalLightCascades = new Vector3(0.05F, 0.2F, 0.3F);
-                    defaultShadowSettings.directionalLightCascadeCount = 4;
-                    defaultShadowSettings.directionalLightNearPlaneOffset = 5;
-                    defaultShadowSettings.maxShadowDistance = 1000.0F;
-                }
-                return defaultShadowSettings;
-            }
-        }
+        public bool     enabled = true;
+        public float    maxShadowDistance = kDefaultMaxShadowDistance;
+        public float    directionalLightNearPlaneOffset = kDefaultDirectionalNearPlaneOffset;
     }
 
     [GenerateHLSL]

--- a/Assets/ScriptableRenderPipeline/Core/TextureSettings.cs
+++ b/Assets/ScriptableRenderPipeline/Core/TextureSettings.cs
@@ -1,22 +1,14 @@
 namespace UnityEngine.Experimental.Rendering
 {
     [System.Serializable]
-    public struct TextureSettings
+    public class TextureSettings
     {
-        public int spotCookieSize;
-        public int pointCookieSize;
-        public int reflectionCubemapSize;
+        public const int kDefaultSpotCookieSize = 128;
+        public const int kDefaultPointCookieSize = 512;
+        public const int kDefaultReflectionCubemapSize = 128;
 
-        public static TextureSettings Default
-        {
-            get
-            {
-                TextureSettings settings = new TextureSettings();
-                settings.spotCookieSize = 128;
-                settings.pointCookieSize = 512;
-                settings.reflectionCubemapSize = 128;
-                return settings;
-            }
-        }
+        public int spotCookieSize = kDefaultSpotCookieSize;
+        public int pointCookieSize = kDefaultPointCookieSize;
+        public int reflectionCubemapSize = kDefaultReflectionCubemapSize;
     }
 }

--- a/Assets/ScriptableRenderPipeline/Fptl/FptlLighting.cs
+++ b/Assets/ScriptableRenderPipeline/Fptl/FptlLighting.cs
@@ -14,13 +14,13 @@ namespace UnityEngine.Experimental.Rendering.Fptl
         static ComputeBuffer    s_ShadowDataBuffer;
         static ComputeBuffer    s_ShadowPayloadBuffer;
 
-        public ShadowSetup(ShadowSettings shadowSettings, out IShadowManager shadowManager)
+        public ShadowSetup(ShadowInitParameters shadowInit, ShadowSettings shadowSettings, out IShadowManager shadowManager)
         {
             s_ShadowDataBuffer = new ComputeBuffer(k_MaxShadowDataSlots, System.Runtime.InteropServices.Marshal.SizeOf(typeof(ShadowData)));
             s_ShadowPayloadBuffer = new ComputeBuffer(k_MaxShadowDataSlots * k_MaxPayloadSlotsPerShadowData, System.Runtime.InteropServices.Marshal.SizeOf(typeof(ShadowPayload)));
             ShadowAtlas.AtlasInit atlasInit;
-            atlasInit.baseInit.width                  = (uint)shadowSettings.shadowAtlasWidth;
-            atlasInit.baseInit.height                 = (uint)shadowSettings.shadowAtlasHeight;
+            atlasInit.baseInit.width                  = (uint)shadowInit.shadowAtlasWidth;
+            atlasInit.baseInit.height                 = (uint)shadowInit.shadowAtlasHeight;
             atlasInit.baseInit.slices                 = 1;
             atlasInit.baseInit.shadowmapBits          = 32;
             atlasInit.baseInit.shadowmapFormat        = RenderTextureFormat.Shadowmap;
@@ -30,8 +30,6 @@ namespace UnityEngine.Experimental.Rendering.Fptl
             atlasInit.baseInit.maxPayloadCount        = 0;
             atlasInit.baseInit.shadowSupport          = ShadowmapBase.ShadowSupport.Directional | ShadowmapBase.ShadowSupport.Point | ShadowmapBase.ShadowSupport.Spot;
             atlasInit.shaderKeyword                   = null;
-            atlasInit.cascadeCount                    = shadowSettings.directionalLightCascadeCount;
-            atlasInit.cascadeRatios                   = shadowSettings.directionalLightCascades;
 
             m_Shadowmaps = new ShadowmapBase[] { new ShadowAtlas(ref atlasInit) };
 
@@ -141,7 +139,7 @@ namespace UnityEngine.Experimental.Rendering.Fptl
         }
 
         [SerializeField]
-        ShadowSettings m_ShadowSettings = ShadowSettings.Default;
+        ShadowSettings m_ShadowSettings = new ShadowSettings();
         ShadowSetup    m_ShadowSetup;
         IShadowManager m_ShadowMgr;
         FrameId        m_FrameId = new FrameId();
@@ -151,7 +149,7 @@ namespace UnityEngine.Experimental.Rendering.Fptl
 
         void InitShadowSystem(ShadowSettings shadowSettings)
         {
-            m_ShadowSetup = new ShadowSetup(shadowSettings, out m_ShadowMgr);
+            m_ShadowSetup = new ShadowSetup(new ShadowInitParameters(), shadowSettings, out m_ShadowMgr);
         }
 
         void DeinitShadowSystem()
@@ -166,7 +164,7 @@ namespace UnityEngine.Experimental.Rendering.Fptl
 
 
         [SerializeField]
-        TextureSettings m_TextureSettings = TextureSettings.Default;
+        TextureSettings m_TextureSettings = new TextureSettings();
 
         public Shader deferredShader;
         public Shader deferredReflectionShader;

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Editor/HDRenderPipelineInspector.cs
@@ -90,6 +90,15 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         SerializedProperty m_Profiles = null;
         SerializedProperty m_NumProfiles = null;
 
+        // Shadow Settings
+        SerializedProperty m_ShadowAtlasWidth = null;
+        SerializedProperty m_ShadowAtlasHeight = null;
+
+        // Texture Settings
+        SerializedProperty m_SpotCookieSize = null;
+        SerializedProperty m_PointCookieSize = null;
+        SerializedProperty m_ReflectionCubemapSize = null;
+
         private void InitializeProperties()
         {
             m_DefaultDiffuseMaterial = serializedObject.FindProperty("m_DefaultDiffuseMaterial");
@@ -108,8 +117,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_tileDebugByCategory = FindProperty(x => x.tileSettings.tileDebugByCategory);
 
             // Shadow settings
+            m_ShadowAtlasWidth = FindProperty(x => x.shadowInitParams.shadowAtlasWidth);
+            m_ShadowAtlasHeight = FindProperty(x => x.shadowInitParams.shadowAtlasHeight);
 
-            //TODO!
+            // Texture settings
+            m_SpotCookieSize = FindProperty(x => x.textureSettings.spotCookieSize);
+            m_PointCookieSize = FindProperty(x => x.textureSettings.pointCookieSize);
+            m_ReflectionCubemapSize = FindProperty(x => x.textureSettings.reflectionCubemapSize);
 
             // Rendering settings
             m_RenderingUseForwardOnly = FindProperty(x => x.renderingSettings.useForwardRenderingOnly);
@@ -196,14 +210,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         private void ShadowSettingsUI(HDRenderPipelineAsset renderContext)
         {
             EditorGUILayout.Space();
-            var shadowSettings = renderContext.shadowSettings;
 
             EditorGUILayout.LabelField(styles.shadowSettings);
             EditorGUI.indentLevel++;
             EditorGUI.BeginChangeCheck();
 
-            shadowSettings.shadowAtlasWidth = Mathf.Max(0, EditorGUILayout.IntField(styles.shadowsAtlasWidth, shadowSettings.shadowAtlasWidth));
-            shadowSettings.shadowAtlasHeight = Mathf.Max(0, EditorGUILayout.IntField(styles.shadowsAtlasHeight, shadowSettings.shadowAtlasHeight));
+            EditorGUILayout.PropertyField(m_ShadowAtlasWidth, styles.shadowsAtlasWidth);
+            EditorGUILayout.PropertyField(m_ShadowAtlasHeight, styles.shadowsAtlasHeight);
 
             if (EditorGUI.EndChangeCheck())
             {
@@ -225,19 +238,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         private void TextureSettingsUI(HDRenderPipelineAsset renderContext)
         {
             EditorGUILayout.Space();
-            var textureSettings = renderContext.textureSettings;
 
             EditorGUILayout.LabelField(styles.textureSettings);
             EditorGUI.indentLevel++;
             EditorGUI.BeginChangeCheck();
 
-            textureSettings.spotCookieSize = Mathf.NextPowerOfTwo(Mathf.Clamp(EditorGUILayout.IntField(styles.spotCookieSize, textureSettings.spotCookieSize), 16, 1024));
-            textureSettings.pointCookieSize = Mathf.NextPowerOfTwo(Mathf.Clamp(EditorGUILayout.IntField(styles.pointCookieSize, textureSettings.pointCookieSize), 16, 1024));
-            textureSettings.reflectionCubemapSize = Mathf.NextPowerOfTwo(Mathf.Clamp(EditorGUILayout.IntField(styles.reflectionCubemapSize, textureSettings.reflectionCubemapSize), 64, 1024));
+            EditorGUILayout.PropertyField(m_SpotCookieSize, styles.spotCookieSize);
+            EditorGUILayout.PropertyField(m_PointCookieSize, styles.pointCookieSize);
+            EditorGUILayout.PropertyField(m_ReflectionCubemapSize, styles.reflectionCubemapSize);
 
             if (EditorGUI.EndChangeCheck())
             {
-                renderContext.textureSettings = textureSettings;
                 HackSetDirty(renderContext); // Repaint
             }
             EditorGUI.indentLevel--;

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipelineAsset.asset
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipelineAsset.asset
@@ -22,7 +22,7 @@ MonoBehaviour:
     - {fileID: 11400000, guid: d6ee4403015766f4093158d69216c0bf, type: 2}
     - {fileID: 11400000, guid: 906339bac2066fc4aa22a3652e1283ef, type: 2}
   tileSettings:
-    enableTileAndCluster: 1
+    enableTileAndCluster: 0
     enableSplitLightEvaluation: 1
     enableComputeLightEvaluation: 0
     enableComputeFeatureVariants: 0
@@ -32,32 +32,13 @@ MonoBehaviour:
     diffuseGlobalDimmer: 1
     specularGlobalDimmer: 1
     tileDebugByCategory: 0
-  m_ShadowSettings:
-    enabled: 1
-    shadowAtlasWidth: 4096
+  shadowInitParams:
+    shadowAtlasWidth: 2048
     shadowAtlasHeight: 4096
-    maxShadowDistance: 1000
-    directionalLightCascadeCount: 4
-    directionalLightCascades: {x: 0.05, y: 0.2, z: 0.3}
-    directionalLightNearPlaneOffset: 5
-  m_TextureSettings:
+  textureSettings:
     spotCookieSize: 128
     pointCookieSize: 512
     reflectionCubemapSize: 128
-  m_CommonSettings:
-    m_ShadowMaxDistance: 1000
-    m_ShadowCascadeCount: 4
-    m_ShadowCascadeSplit0: 0.05
-    m_ShadowCascadeSplit1: 0.2
-    m_ShadowCascadeSplit2: 0.3
-    m_ShadowNearPlaneOffset: 5
-  m_SkySettings: {fileID: 0}
-  m_SsaoSettings:
-    m_Enable: 0
-    m_Intensity: 1
-    m_Radius: 0.5
-    m_SampleCount: 8
-    m_Downsampling: 1
   m_DefaultDiffuseMaterial: {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17,
     type: 2}
   m_DefaultShader: {fileID: 4800000, guid: 6e4ae4064600d784cac1e41a9e6f2e59, type: 3}

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipelineAsset.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipelineAsset.cs
@@ -61,70 +61,17 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // NOTE: All those properties are public because of how HDRenderPipelineInspector retrieve those properties via serialization/reflection
         // Doing it this way allow to change parameters name and still retrieve correct serialized value
 
-        // Debugging (Not persistent)
-        public DebugDisplaySettings debugDisplaySettings = new DebugDisplaySettings();
-
-        // Renderer Settings (per project)
+        // Renderer Settings
         public RenderingSettings renderingSettings = new RenderingSettings();
         public SubsurfaceScatteringSettings sssSettings = new SubsurfaceScatteringSettings();
         public TileSettings tileSettings = new TileSettings();
 
-        // TODO: Following two settings need to be update to the serialization/reflection way like above
-        [SerializeField]
-        ShadowSettings m_ShadowSettings = ShadowSettings.Default;
-        [SerializeField]
-        TextureSettings m_TextureSettings = TextureSettings.Default;
+        // Shadow Settings
+        public ShadowInitParameters shadowInitParams = new ShadowInitParameters();
 
-        public ShadowSettings shadowSettings
-        {
-            get { return m_ShadowSettings; }
-        }
+        // Texture Settings
+        public TextureSettings textureSettings = new TextureSettings();
 
-        public TextureSettings textureSettings
-        {
-            get { return m_TextureSettings; }
-            set { m_TextureSettings = value; }
-        }
-
-        // NOTE: Following settings are Asset so they need to be serialized as usual. no reflection/serialization here
-
-        // Renderer Settings (per "scene")
-        [SerializeField]
-        private CommonSettings.Settings m_CommonSettings = CommonSettings.Settings.s_Defaultsettings;
-        [SerializeField]
-        private SkySettings m_SkySettings;
-
-        public CommonSettings.Settings commonSettingsToUse
-        {
-            get
-            {
-                if (CommonSettingsSingleton.overrideSettings)
-                    return CommonSettingsSingleton.overrideSettings.settings;
-
-                return m_CommonSettings;
-            }
-        }
-
-        /*
-        public SkySettings skySettings
-        {
-            get { return m_SkySettings; }
-            set { m_SkySettings = value; }
-        }
-        */
-
-        public SkySettings skySettingsToUse
-        {
-            get
-            {
-                if (SkySettingsSingleton.overrideSettings)
-                    return SkySettingsSingleton.overrideSettings;
-
-                return m_SkySettings;
-            }
-        }
-
-        [SerializeField]
         private ScreenSpaceAmbientOcclusionSettings.Settings m_SsaoSettings = ScreenSpaceAmbientOcclusionSettings.Settings.s_Defaultsettings;
 
         public ScreenSpaceAmbientOcclusionSettings.Settings ssaoSettingsToUse
@@ -202,39 +149,10 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             return null;
         }
 
-        public void ApplyDebugDisplaySettings()
-        {
-            m_ShadowSettings.enabled = debugDisplaySettings.lightingDebugSettings.enableShadows;
-
-            LightingDebugSettings lightingDebugSettings = debugDisplaySettings.lightingDebugSettings;
-            Vector4 debugAlbedo = new Vector4(lightingDebugSettings.debugLightingAlbedo.r, lightingDebugSettings.debugLightingAlbedo.g, lightingDebugSettings.debugLightingAlbedo.b, 0.0f);
-            Vector4 debugSmoothness = new Vector4(lightingDebugSettings.overrideSmoothness ? 1.0f : 0.0f, lightingDebugSettings.overrideSmoothnessValue, 0.0f, 0.0f);
-
-            Shader.SetGlobalInt("_DebugViewMaterial", (int)debugDisplaySettings.GetDebugMaterialIndex());
-            Shader.SetGlobalInt("_DebugLightingMode", (int)debugDisplaySettings.GetDebugLightingMode());
-            Shader.SetGlobalVector("_DebugLightingAlbedo", debugAlbedo);
-            Shader.SetGlobalVector("_DebugLightingSmoothness", debugSmoothness);
-        }
-
-        public void UpdateCommonSettings()
-        {
-            var commonSettings = commonSettingsToUse;
-
-            m_ShadowSettings.directionalLightCascadeCount = commonSettings.shadowCascadeCount;
-            m_ShadowSettings.directionalLightCascades = new Vector3(commonSettings.shadowCascadeSplit0, commonSettings.shadowCascadeSplit1, commonSettings.shadowCascadeSplit2);
-            m_ShadowSettings.maxShadowDistance = commonSettings.shadowMaxDistance;
-            m_ShadowSettings.directionalLightNearPlaneOffset = commonSettings.shadowNearPlaneOffset;
-        }
 
         public void OnValidate()
         {
-            debugDisplaySettings.OnValidate();
             sssSettings.OnValidate();
-        }
-
-        void OnEnable()
-        {
-            debugDisplaySettings.RegisterDebug();
         }
     }
 }

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -14,13 +14,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         static ComputeBuffer    s_ShadowDataBuffer;
         static ComputeBuffer    s_ShadowPayloadBuffer;
 
-        public ShadowSetup(ShadowSettings shadowSettings, out IShadowManager shadowManager)
+        public ShadowSetup(ShadowInitParameters shadowInit, ShadowSettings shadowSettings, out IShadowManager shadowManager)
         {
             s_ShadowDataBuffer      = new ComputeBuffer( k_MaxShadowDataSlots, System.Runtime.InteropServices.Marshal.SizeOf( typeof( ShadowData ) ) );
             s_ShadowPayloadBuffer   = new ComputeBuffer( k_MaxShadowDataSlots * k_MaxPayloadSlotsPerShadowData, System.Runtime.InteropServices.Marshal.SizeOf( typeof( ShadowPayload ) ) );
             ShadowAtlas.AtlasInit atlasInit;
-            atlasInit.baseInit.width           = (uint)shadowSettings.shadowAtlasWidth;
-            atlasInit.baseInit.height          = (uint)shadowSettings.shadowAtlasHeight;
+            atlasInit.baseInit.width           = (uint)shadowInit.shadowAtlasWidth;
+            atlasInit.baseInit.height          = (uint)shadowInit.shadowAtlasHeight;
             atlasInit.baseInit.slices          = 1;
             atlasInit.baseInit.shadowmapBits   = 32;
             atlasInit.baseInit.shadowmapFormat = RenderTextureFormat.Shadowmap;
@@ -30,8 +30,6 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             atlasInit.baseInit.maxPayloadCount = 0;
             atlasInit.baseInit.shadowSupport   = ShadowmapBase.ShadowSupport.Directional | ShadowmapBase.ShadowSupport.Point | ShadowmapBase.ShadowSupport.Spot;
             atlasInit.shaderKeyword            = null;
-            atlasInit.cascadeCount             = shadowSettings.directionalLightCascadeCount;
-            atlasInit.cascadeRatios            = shadowSettings.directionalLightCascades;
 
             var varianceInit = atlasInit;
             varianceInit.baseInit.shadowmapFormat = ShadowVariance.GetFormat( false, false, true );
@@ -410,9 +408,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             List<int>               m_ShadowRequests = new List<int>();
             Dictionary<int, int>    m_ShadowIndices = new Dictionary<int, int>();
 
-            void InitShadowSystem(ShadowSettings shadowSettings)
+            void InitShadowSystem(ShadowInitParameters initParam, ShadowSettings shadowSettings)
             {
-                m_ShadowSetup = new ShadowSetup(shadowSettings, out m_ShadowMgr);
+                m_ShadowSetup = new ShadowSetup(initParam, shadowSettings, out m_ShadowMgr);
             }
 
             void DeinitShadowSystem()
@@ -457,7 +455,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             public LightLoop()
             {}
 
-            public void Build(RenderPipelineResources renderPipelineResources, TileSettings tileSettings, TextureSettings textureSettings)
+            public void Build(RenderPipelineResources renderPipelineResources, TileSettings tileSettings, TextureSettings textureSettings, ShadowInitParameters shadowInit, ShadowSettings shadowSettings)
             {
                 m_Resources = renderPipelineResources;
                 m_TileSettings = tileSettings;
@@ -606,7 +604,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 UnityEditor.SceneView.onSceneGUIDelegate += OnSceneGUI;
 #endif
 
-                InitShadowSystem(ShadowSettings.Default);
+                InitShadowSystem(shadowInit, shadowSettings);
             }
 
             public void Cleanup()

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePassLoop.hlsl
@@ -30,12 +30,13 @@ void ApplyDebug(LightLoopContext lightLoopContext, float3 positionWS, inout floa
         int shadowSplitIndex = EvalShadow_GetSplitSphereIndexForDirshadows(positionWS, dirShadowSplitSpheres);
 
         if (shadowSplitIndex == -1)
+        {
             diffuseLighting = float3(0.0, 0.0, 0.0);
+        }
         else
         {
             diffuseLighting = s_CascadeColors[shadowSplitIndex] * shadow;
         }
-
     }
 #endif
 }

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/SceneSettings/CommonSettings.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/SceneSettings/CommonSettings.cs
@@ -11,41 +11,21 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             [SerializeField]
             float m_ShadowMaxDistance;
             [SerializeField]
-            int   m_ShadowCascadeCount;
-            [SerializeField]
-            float m_ShadowCascadeSplit0;
-            [SerializeField]
-            float m_ShadowCascadeSplit1;
-            [SerializeField]
-            float m_ShadowCascadeSplit2;
-            [SerializeField]
             float m_ShadowNearPlaneOffset;
 
             public float shadowMaxDistance      { set { m_ShadowMaxDistance   = value; OnValidate(); } get { return m_ShadowMaxDistance; } }
-            public int   shadowCascadeCount     { set { m_ShadowCascadeCount  = value; OnValidate(); } get { return m_ShadowCascadeCount; } }
-            public float shadowCascadeSplit0    { set { m_ShadowCascadeSplit0 = value; OnValidate(); } get { return m_ShadowCascadeSplit0; } }
-            public float shadowCascadeSplit1    { set { m_ShadowCascadeSplit1 = value; OnValidate(); } get { return m_ShadowCascadeSplit1; } }
-            public float shadowCascadeSplit2    { set { m_ShadowCascadeSplit2 = value; OnValidate(); } get { return m_ShadowCascadeSplit2; } }
             public float shadowNearPlaneOffset  { set { m_ShadowNearPlaneOffset = value; OnValidate(); } get { return m_ShadowNearPlaneOffset; } }
 
             void OnValidate()
             {
                 m_ShadowMaxDistance     = Mathf.Max(0.0f, m_ShadowMaxDistance);
-                m_ShadowCascadeCount    = Mathf.Min(4, Mathf.Max(1, m_ShadowCascadeCount));
-                m_ShadowCascadeSplit0   = Mathf.Clamp01(m_ShadowCascadeSplit0);
-                m_ShadowCascadeSplit1   = Mathf.Clamp01(m_ShadowCascadeSplit1);
-                m_ShadowCascadeSplit2   = Mathf.Clamp01(m_ShadowCascadeSplit2);
                 m_ShadowNearPlaneOffset = Mathf.Max(0, m_ShadowNearPlaneOffset);
             }
 
             public static readonly Settings s_Defaultsettings = new Settings
             {
-                m_ShadowMaxDistance     = ShadowSettings.Default.maxShadowDistance,
-                m_ShadowCascadeCount    = ShadowSettings.Default.directionalLightCascadeCount,
-                m_ShadowCascadeSplit0   = ShadowSettings.Default.directionalLightCascades.x,
-                m_ShadowCascadeSplit1   = ShadowSettings.Default.directionalLightCascades.y,
-                m_ShadowCascadeSplit2   = ShadowSettings.Default.directionalLightCascades.z,
-                m_ShadowNearPlaneOffset = ShadowSettings.Default.directionalLightNearPlaneOffset,
+                m_ShadowMaxDistance     = ShadowSettings.kDefaultMaxShadowDistance,
+                m_ShadowNearPlaneOffset = ShadowSettings.kDefaultDirectionalNearPlaneOffset,
             };
         }
 

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/SceneSettings/Editor/CommonSettingsEditor.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/SceneSettings/Editor/CommonSettingsEditor.cs
@@ -15,18 +15,8 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
     {
         private class Styles
         {
-            public readonly GUIContent none = new GUIContent("None");
-            public readonly GUIContent sky = new GUIContent("Sky");
-            public readonly GUIContent skyRenderer = new GUIContent("Sky Renderer");
-
-            public readonly GUIContent shadows = new GUIContent("Shadows");
             public readonly GUIContent maxShadowDistance = new GUIContent("Maximum shadow distance");
-            public readonly GUIContent shadowsDirectionalLightCascadeCount = new GUIContent("Directional cascade count");
-            public readonly GUIContent[] shadowsCascadeCounts = new GUIContent[] { new GUIContent("1"), new GUIContent("2"), new GUIContent("3"), new GUIContent("4") };
-            public readonly int[] shadowsCascadeCountValues = new int[] { 1, 2, 3, 4 };
-            public readonly GUIContent shadowsCascades = new GUIContent("Cascade values");
-            public readonly GUIContent[] shadowSplits = new GUIContent[] { new GUIContent("Split 0"), new GUIContent("Split 1"), new GUIContent("Split 2") };
-            public readonly GUIContent nearPlaneOffset = new GUIContent("Near plane offset");
+            public readonly GUIContent nearPlaneOffset = new GUIContent("Shadow near plane offset");
         }
 
         private static Styles s_Styles = null;
@@ -40,129 +30,23 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
         }
 
-        // Sky renderer
-        List<Type> m_SkyRendererTypes = new List<Type>();
-        private List<GUIContent> m_SkyRendererTypeNames = new List<GUIContent>();
-        private List<string> m_SkyRendererFullTypeNames = new List<string>();
-        private List<int> m_SkyRendererTypeValues = new List<int>();
-
-        private bool multipleEditing { get { return targets.Length > 1; } }
-
-        private SerializedProperty m_SkyRenderer;
-
         private SerializedProperty m_ShadowMaxDistance;
-        private SerializedProperty m_ShadowCascadeCount;
-        private SerializedProperty[] m_ShadowCascadeSplits = new SerializedProperty[3];
         private SerializedProperty m_ShadowNearPlaneOffset;
 
         void OnEnable()
         {
-            m_SkyRenderer = serializedObject.FindProperty("m_SkyRendererTypeName");
-
-            m_ShadowMaxDistance = serializedObject.FindProperty("m_ShadowMaxDistance");
-            m_ShadowCascadeCount = serializedObject.FindProperty("m_ShadowCascadeCount");
-            for (int i = 0; i < 3; ++i)
-                m_ShadowCascadeSplits[i] = serializedObject.FindProperty(string.Format("m_ShadowCascadeSplit{0}", i));
-            m_ShadowNearPlaneOffset = serializedObject.FindProperty("m_ShadowNearPlaneOffset");
-
-            m_SkyRendererTypes = Assembly.GetAssembly(typeof(SkyRenderer))
-                .GetTypes()
-                .Where(t => t.IsSubclassOf(typeof(SkyRenderer)) && !t.IsGenericType)
-                .ToList();
-
-            // Prepare the list of available SkyRenderers for the IntPopup
-            m_SkyRendererTypeNames.Clear();
-            m_SkyRendererFullTypeNames.Clear();
-            m_SkyRendererTypeValues.Clear();
-            for (int i = 0; i < m_SkyRendererTypes.Count; ++i)
-            {
-                string longName = m_SkyRendererTypes[i].ToString();
-                m_SkyRendererFullTypeNames.Add(longName);
-                char[] separators = {'.'};
-                string[] tokens = longName.Split(separators);
-                m_SkyRendererTypeNames.Add(new GUIContent(tokens[tokens.Length - 1]));
-                m_SkyRendererTypeValues.Add(i);
-            }
-
-            // Add default null value.
-            m_SkyRendererTypeNames.Add(styles.none);
-            m_SkyRendererFullTypeNames.Add("");
-            m_SkyRendererTypeValues.Add(m_SkyRendererTypeValues.Count);
-            m_SkyRendererTypes.Add(null);
+            m_ShadowMaxDistance = serializedObject.FindProperty("m_Settings.m_ShadowMaxDistance");
+            m_ShadowNearPlaneOffset = serializedObject.FindProperty("m_Settings.m_ShadowNearPlaneOffset");
         }
 
-        void OnSkyInspectorGUI()
-        {
-            EditorGUILayout.LabelField(styles.sky);
-            EditorGUI.indentLevel++;
-
-            // Retrieve the index of the current SkyRenderer. Won't be used in case of multiple editing with different values
-            int index = -1;
-            for (int i = 0; i < m_SkyRendererTypeNames.Count; ++i)
-            {
-                if (m_SkyRendererFullTypeNames[i] == m_SkyRenderer.stringValue)
-                {
-                    index = i;
-                    break;
-                }
-            }
-
-            EditorGUI.showMixedValue = m_SkyRenderer.hasMultipleDifferentValues;
-            EditorGUI.BeginChangeCheck();
-            int newValue = EditorGUILayout.IntPopup(styles.skyRenderer, index, m_SkyRendererTypeNames.ToArray(), m_SkyRendererTypeValues.ToArray());
-            if (EditorGUI.EndChangeCheck())
-            {
-                m_SkyRenderer.stringValue = m_SkyRendererFullTypeNames[newValue];
-            }
-            EditorGUI.showMixedValue = false;
-
-            EditorGUI.indentLevel--;
-        }
-
-        void OnShadowInspectorGUI()
-        {
-            EditorGUILayout.LabelField(styles.shadows);
-            EditorGUI.indentLevel++;
-            EditorGUILayout.PropertyField(m_ShadowMaxDistance, styles.maxShadowDistance);
-
-            EditorGUI.BeginChangeCheck();
-            EditorGUI.showMixedValue = m_ShadowCascadeCount.hasMultipleDifferentValues;
-            int newCascadeCount = EditorGUILayout.IntPopup(styles.shadowsDirectionalLightCascadeCount, m_ShadowCascadeCount.intValue, styles.shadowsCascadeCounts, styles.shadowsCascadeCountValues);
-            if (EditorGUI.EndChangeCheck())
-            {
-                m_ShadowCascadeCount.intValue = newCascadeCount;
-            }
-
-            // Compute max cascade count.
-            int maxCascadeCount = 0;
-            for (int i = 0; i < targets.Length; ++i)
-            {
-                CommonSettings settings = targets[i] as CommonSettings;
-                maxCascadeCount = Math.Max(maxCascadeCount, settings.settings.shadowCascadeCount);
-            }
-
-            EditorGUI.indentLevel++;
-            for (int i = 0; i < maxCascadeCount - 1; i++)
-            {
-                EditorGUILayout.PropertyField(m_ShadowCascadeSplits[i], styles.shadowSplits[i]);
-            }
-            EditorGUI.indentLevel--;
-
-            EditorGUILayout.PropertyField(m_ShadowNearPlaneOffset, styles.nearPlaneOffset);
-
-            EditorGUI.indentLevel--;
-        }
-
-        /*
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
 
-            OnSkyInspectorGUI();
-            OnShadowInspectorGUI();
+            EditorGUILayout.PropertyField(m_ShadowMaxDistance, styles.maxShadowDistance);
+            EditorGUILayout.PropertyField(m_ShadowNearPlaneOffset, styles.nearPlaneOffset);
 
             serializedObject.ApplyModifiedProperties();
         }
-        */
     }
 }


### PR DESCRIPTION
- Cleaned up CommonSettings from Cascaded parameters which are now in the light.
- Cleaned up some now useless code in the init code of shadow system
- Split ShadowSettings struct into two different parts. One for the init and the other for the per frame setup
- Cleaned up HDRenderPipeline a bit (mostly moving logic stuff from the asset to the instance itself)
