### PR TITLE
Fixed motion vectors and camera relative rendering

### DIFF
--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/RenderPipelineResources/CameraMotionVectors.shader
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/RenderPipelineResources/CameraMotionVectors.shader
@@ -6,9 +6,12 @@ Shader "Hidden/HDRenderPipeline/CameraMotionVectors"
 
         #include "../../ShaderLibrary/Common.hlsl"
         #include "../ShaderVariables.hlsl"
+        #include "../ShaderConfig.cs.hlsl"
         #include "../ShaderPass/FragInputs.hlsl"
         #include "../ShaderPass/VaryingMesh.hlsl"
         #include "../ShaderPass/VertMesh.hlsl"
+
+        float4 _CameraPosDiff;
 
         struct Attributes
         {
@@ -33,14 +36,24 @@ Shader "Hidden/HDRenderPipeline/CameraMotionVectors"
             float depth = LOAD_TEXTURE2D(_MainDepthTexture, posInput.unPositionSS).x;
             UpdatePositionInput(depth, _InvViewProjMatrix, _ViewProjMatrix, posInput);
             float4 worldPos = float4(posInput.positionWS, 1.0);
+            float4 prevPos = worldPos;
 
-            float4 prevClipPos = mul(_PrevViewProjMatrix, worldPos);
+        #if (SHADEROPTIONS_CAMERA_RELATIVE_RENDERING != 0)
+            prevPos -= _CameraPosDiff;
+        #endif
+
+            float4 prevClipPos = mul(_PrevViewProjMatrix, prevPos);
             float4 curClipPos = mul(_NonJitteredViewProjMatrix, worldPos);
             float2 prevHPos = prevClipPos.xy / prevClipPos.w;
             float2 curHPos = curClipPos.xy / curClipPos.w;
 
             float2 previousPositionCS = (prevHPos + 1.0) / 2.0;
             float2 positionCS = (curHPos + 1.0) / 2.0;
+
+        #if UNITY_UV_STARTS_AT_TOP
+            previousPositionCS.y = 1.0 - previousPositionCS.y;
+            positionCS.y = 1.0 - positionCS.y;
+        #endif
 
             return float4(positionCS - previousPositionCS, 0.0, 1.0);
         }


### PR DESCRIPTION
When relative rendering is enabled the camera position is always zero'd, so camera motion vectors only work with rotations.