### PR TITLE
Various fix for debug modes:

### DIFF
--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugDisplay.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugDisplay.cs
@@ -421,6 +421,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         }
 
 
+        public bool IsDebugGBufferEnabled()
+        {
+            return m_DebugViewGBuffer != 0;
+        }
+
         public bool IsDebugDisplayEnabled()
         {
             return (m_DebugViewEngine != 0 || m_DebugViewMaterial != 0 || m_DebugViewVarying != Attributes.DebugViewVarying.None || m_DebugViewProperties != Attributes.DebugViewProperties.None || m_DebugViewGBuffer != 0);

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugViewMaterialGBuffer.shader
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugViewMaterialGBuffer.shader
@@ -5,7 +5,7 @@ Shader "Hidden/HDRenderPipeline/DebugViewMaterialGBuffer"
         Pass
         {
             ZWrite Off
-            Blend SrcAlpha OneMinusSrcAlpha // We will lerp only the values that are valid
+            Blend One Zero
 
             HLSLPROGRAM
             #pragma target 4.5

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugViewMaterialGBuffer.shader
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Debug/DebugViewMaterialGBuffer.shader
@@ -5,7 +5,6 @@ Shader "Hidden/HDRenderPipeline/DebugViewMaterialGBuffer"
         Pass
         {
             ZWrite Off
-            Blend One Zero
 
             HLSLPROGRAM
             #pragma target 4.5

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -1025,12 +1025,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             using (new Utilities.ProfilingSample("DisplayDebug ViewMaterial", cmd))
             {
-                // Render Opaque forward
-                Utilities.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT, Utilities.kClearAll, Color.black);
-                RenderOpaqueRenderList(cull, hdCamera.camera, renderContext, cmd, "ForwardDisplayDebug", Utilities.kRendererConfigurationBakedLighting);
-
-                // Render GBuffer opaque
-                if (!m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
+                if(m_DebugDisplaySettings.materialDebugSettings.IsDebugGBufferEnabled() && !m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 {
                     using (new Utilities.ProfilingSample("DebugViewMaterialGBuffer", cmd))
                     {
@@ -1038,9 +1033,13 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                         Utilities.DrawFullScreen(cmd, m_DebugViewMaterialGBuffer, m_CameraColorBufferRT);
                     }
                 }
-
-                // Render forward transparent
+                else
                 {
+                    Utilities.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT, Utilities.kClearAll, Color.black);
+                    // Render Opaque forward
+                    RenderOpaqueRenderList(cull, hdCamera.camera, renderContext, cmd, "ForwardDisplayDebug", Utilities.kRendererConfigurationBakedLighting);
+
+                    // Render forward transparent
                     RenderTransparentRenderList(cull, hdCamera.camera, renderContext, cmd, "ForwardDisplayDebug", Utilities.kRendererConfigurationBakedLighting);
                 }
             }

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.hlsl
@@ -174,7 +174,7 @@ void GetPreIntegratedFGD(float NdotV, float perceptualRoughness, float3 fresnel0
 #endif
 }
 
-void ApplyDebugToBSDFData(inout BSDFData bsdfData)
+void ApplyDebugToSurfaceData(inout SurfaceData surfaceData)
 {
 #ifdef DEBUG_DISPLAY
     if (_DebugLightingMode == DEBUGLIGHTINGMODE_SPECULAR_LIGHTING)
@@ -184,14 +184,13 @@ void ApplyDebugToBSDFData(inout BSDFData bsdfData)
 
         if (overrideSmoothness)
         {
-            bsdfData.perceptualRoughness = PerceptualSmoothnessToPerceptualRoughness(overrideSmoothnessValue);
-            bsdfData.roughness = PerceptualRoughnessToRoughness(bsdfData.perceptualRoughness);
+            surfaceData.perceptualSmoothness = overrideSmoothnessValue;
         }
     }
 
     if (_DebugLightingMode == DEBUGLIGHTINGMODE_DIFFUSE_LIGHTING)
     {
-        bsdfData.diffuseColor = _DebugLightingAlbedo.xyz;
+        surfaceData.baseColor = _DebugLightingAlbedo.xyz;
     }
 #endif
 }
@@ -268,6 +267,8 @@ void FillMaterialIdSSSData(float3 baseColor, int subsurfaceProfile, float subsur
 
 BSDFData ConvertSurfaceDataToBSDFData(SurfaceData surfaceData)
 {
+    ApplyDebugToSurfaceData(surfaceData);
+
     BSDFData bsdfData;
     ZERO_INITIALIZE(BSDFData, bsdfData);
 
@@ -300,8 +301,6 @@ BSDFData ConvertSurfaceDataToBSDFData(SurfaceData surfaceData)
         FillMaterialIdSSSData(surfaceData.baseColor, surfaceData.subsurfaceProfile, surfaceData.subsurfaceRadius, surfaceData.thickness, bsdfData);
     }
 
-    ApplyDebugToBSDFData(bsdfData);
-
     return bsdfData;
 }
 
@@ -327,6 +326,8 @@ void EncodeIntoGBuffer( SurfaceData surfaceData,
     #if SHADEROPTIONS_PACK_GBUFFER_IN_U16
     float4 outGBuffer0, outGBuffer1, outGBuffer2, outGBuffer3;
     #endif
+
+    ApplyDebugToSurfaceData(surfaceData);
 
     // RT0 - 8:8:8:8 sRGB
     outGBuffer0 = float4(surfaceData.baseColor, surfaceData.specularOcclusion);
@@ -531,8 +532,6 @@ void DecodeFromGBuffer(
     }
 
     bakeDiffuseLighting = inGBuffer3.rgb;
-
-    ApplyDebugToBSDFData(bsdfData);
 }
 
 uint MaterialFeatureFlagsFromGBuffer(

--- a/Assets/ScriptableRenderPipeline/HDRenderPipeline/ShaderPass/ShaderPassForward.hlsl
+++ b/Assets/ScriptableRenderPipeline/HDRenderPipeline/ShaderPass/ShaderPassForward.hlsl
@@ -1,4 +1,4 @@
-#if SHADERPASS != SHADERPASS_FORWARD
+﻿#if SHADERPASS != SHADERPASS_FORWARD
 #error SHADERPASS_is_not_correctly_define
 #endif
 
@@ -46,6 +46,13 @@ void Frag(PackedVaryingsToPS packedInput,
 
     PreLightData preLightData = GetPreLightData(V, posInput, bsdfData);
 
+    outColor = float4(0.0, 0.0, 0.0, 0.0);
+
+    // We need to skip lighting when doing debug pass because the debug pass is done before lighting so some buffers may not be properly initialized potentially causing crashes on PS4.
+#ifdef DEBUG_DISPLAY
+    if (_DebugLightingMode != DEBUGLIGHTINGMODE_NONE)
+#endif
+    {
     uint featureFlags = 0xFFFFFFFF;
     float3 diffuseLighting;
     float3 specularLighting;
@@ -53,6 +60,7 @@ void Frag(PackedVaryingsToPS packedInput,
     LightLoop(V, posInput, preLightData, bsdfData, bakeDiffuseLighting, featureFlags, diffuseLighting, specularLighting);
 
     outColor = float4(diffuseLighting + specularLighting, builtinData.opacity);
+    }
 
 #ifdef _DEPTHOFFSET_ON
     outputDepth = posInput.depthRaw;


### PR DESCRIPTION
- Debug Diffuse Lighting albedo override now works correctly for SSS materials.
- GBuffer debug now only shows GBuffer enabled material (no more forward only materials)
- Changed previous fix of PS4 crash in ShaderPassForward (it caused debug lighting for transparent objects to break).