### PR TITLE
Add XR Support to BasicRenderPipeline

### DIFF
--- a/Assets/ScriptableRenderPipeline/BasicRenderPipeline/BasicRenderPipeline.cs
+++ b/Assets/ScriptableRenderPipeline/BasicRenderPipeline/BasicRenderPipeline.cs
@@ -15,6 +15,8 @@ using UnityEngine.XR;
 [ExecuteInEditMode]
 public class BasicRenderPipeline : RenderPipelineAsset
 {
+    public bool UseIntermediateRenderTargetBlit;
+
 #if UNITY_EDITOR
     [UnityEditor.MenuItem("RenderPipeline/Create BasicRenderPipeline")]
     static void CreateBasicRenderPipeline()
@@ -27,16 +29,28 @@ public class BasicRenderPipeline : RenderPipelineAsset
 
     protected override IRenderPipeline InternalCreatePipeline()
     {
-        return new BasicRenderPipelineInstance();
+        return new BasicRenderPipelineInstance(UseIntermediateRenderTargetBlit);
     }
 }
 
 public class BasicRenderPipelineInstance : RenderPipeline
 {
+    bool useIntermediateBlit;
+
+    public BasicRenderPipelineInstance()
+    {
+        useIntermediateBlit = false;
+    }
+
+    public BasicRenderPipelineInstance(bool useIntermediate)
+    {
+        useIntermediateBlit = useIntermediate;
+    }
+
     public override void Render(ScriptableRenderContext renderContext, Camera[] cameras)
     {
         base.Render(renderContext, cameras);
-        BasicRendering.Render(renderContext, cameras);
+        BasicRendering.Render(renderContext, cameras, useIntermediateBlit);
     }
 }
 
@@ -44,7 +58,7 @@ public static class BasicRendering
 {
     // Main entry point for our scriptable render loop
 
-    public static void Render(ScriptableRenderContext context, IEnumerable<Camera> cameras)
+    public static void Render(ScriptableRenderContext context, IEnumerable<Camera> cameras, bool useIntermediateBlit)
     {
         bool stereoEnabled = XRSettings.isDeviceActive;
 

--- a/Assets/ScriptableRenderPipeline/BasicRenderPipeline/BasicRenderPipelineShader.shader
+++ b/Assets/ScriptableRenderPipeline/BasicRenderPipeline/BasicRenderPipelineShader.shader
@@ -62,6 +62,7 @@ CGPROGRAM
 #pragma target 3.0
 #pragma vertex vert
 #pragma fragment frag
+#pragma multi_compile _ UNITY_SINGLE_PASS_STEREO STEREO_INSTANCING_ON STEREO_MULTIVIEW_ON
 #pragma shader_feature _METALLICGLOSSMAP
 #include "UnityCG.cginc"
 #include "UnityStandardBRDF.cginc"
@@ -155,6 +156,7 @@ struct v2f
     float3 positionWS : TEXCOORD1;
     float3 normalWS : TEXCOORD2;
     float4 hpos : SV_POSITION;
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
 float4 _MainTex_ST;
@@ -162,6 +164,8 @@ float4 _MainTex_ST;
 v2f vert(appdata_base v)
 {
     v2f o;
+    UNITY_SETUP_INSTANCE_ID(v);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
     o.uv = TRANSFORM_TEX(v.texcoord,_MainTex);
     o.hpos = UnityObjectToClipPos(v.vertex);
     o.positionWS = mul(unity_ObjectToWorld, v.vertex).xyz;


### PR DESCRIPTION
This PR uses the new XR APIs in ScriptableRenderContext and CullResults to add XR rendering to BasicRenderPipeline.  This is a simple example of how to add XR support. Porting of other Render Pipelines are likely to need more work.

There are three main changes:
- Usage of new SRP APIs to set up stereo properties (matrices, viewports, RT) and perform stereo rendering.
- Add usage of existing stereo shader infrastructure (from UnityCG.cginc) to BasicRenderPipelineShader.shader
- Add the option of rendering to an intermediate render texture, and then blitting to the final output.  This is to demonstrate the setup of intermediate XR render textures, which is different than setting up a monoscopic render texture.

On top of the SRP and shader changes, Single-Pass Stereo needs to be enabled via the Player Settings.  Any single pass mode should work on any platform that supports Single-Pass Stereo.