### PR TITLE
Add XR Support to LightweightPipeline

### DIFF
--- a/Assets/ScriptableRenderPipeline/LightweightPipeline/LightweightPipeline.cs
+++ b/Assets/ScriptableRenderPipeline/LightweightPipeline/LightweightPipeline.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine.Rendering;
+using UnityEngine.XR;
 
 namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 {
@@ -79,6 +80,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         private RenderTargetIdentifier m_CameraRTID;
 
         private bool m_RenderToIntermediateTarget = false;
+        private bool m_IntermediateTextureArray = false;
 
         private const int kShadowDepthBufferBits = 16;
         private const int kCameraDepthBufferBits = 32;
@@ -125,10 +127,12 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
         {
             base.Render(context, cameras);
 
+            bool stereoEnabled = XRSettings.isDeviceActive;
+
             foreach (Camera camera in cameras)
             {
                 ScriptableCullingParameters cullingParameters;
-                if (!CullResults.GetCullingParameters(camera, out cullingParameters))
+                if (!CullResults.GetCullingParameters(camera, stereoEnabled, out cullingParameters))
                     continue;
 
                 cullingParameters.shadowDistance = Mathf.Min(m_ShadowSettings.maxShadowDistance, camera.farClipPlane);
@@ -144,7 +148,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                     lightData.shadowsRendered = RenderShadows(ref m_CullResults, ref visibleLights[lightData.shadowLightIndex], lightData.shadowLightIndex, ref context);
 
                 // Setup camera matrices and RT
-                context.SetupCameraProperties(camera);
+                context.SetupCameraProperties(camera, stereoEnabled);
 
                 // Setup light and shadow shader constants
                 SetupShaderLightConstants(visibleLights, ref lightData, ref m_CullResults, ref context);
@@ -162,7 +166,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 if (!lightData.isSingleDirectionalLight)
                     configuration |= RendererConfiguration.PerObjectLightIndices8;
 
-                BeginForwardRendering(camera, ref context);
+                BeginForwardRendering(camera, ref context, stereoEnabled);
 
                 // Render Opaques
                 var litSettings = new DrawRendererSettings(m_CullResults, camera, m_LitPassName);
@@ -176,13 +180,6 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
 
                 context.DrawRenderers(ref litSettings);
 
-                // Release temporary RT
-                var discardRT = CommandBufferPool.Get();
-                discardRT.ReleaseTemporaryRT(m_ShadowMapProperty);
-                discardRT.ReleaseTemporaryRT(m_CameraRTProperty);
-                context.ExecuteCommandBuffer(discardRT);
-                CommandBufferPool.Release(discardRT);
-
                 // TODO: Check skybox shader
                 context.DrawSkybox(camera);
 
@@ -192,7 +189,14 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
                 context.DrawRenderers(ref litSettings);
                 context.DrawRenderers(ref unlitSettings);
 
-                EndForwardRendering(camera, ref context);
+                EndForwardRendering(camera, ref context, stereoEnabled);
+
+                // Release temporary RT
+                var discardRT = CommandBufferPool.Get();
+                discardRT.ReleaseTemporaryRT(m_ShadowMapProperty);
+                discardRT.ReleaseTemporaryRT(m_CameraRTProperty);
+                context.ExecuteCommandBuffer(discardRT);
+                CommandBufferPool.Release(discardRT);
             }
 
             context.Submit();
@@ -557,8 +561,11 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             return (type == LightType.Directional || type == LightType.Spot);
         }
 
-        private void BeginForwardRendering(Camera camera, ref ScriptableRenderContext context)
+        private void BeginForwardRendering(Camera camera, ref ScriptableRenderContext context, bool stereoEnabled)
         {
+            if (stereoEnabled)
+                context.StartMultiEye(camera);
+
             m_RenderToIntermediateTarget = GetRenderToIntermediateTarget(camera);
 
             var cmd = CommandBufferPool.Get("SetCameraRenderTarget");
@@ -566,9 +573,28 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             {
                 if (camera.activeTexture == null)
                 {
-                    cmd.GetTemporaryRT(m_CameraRTProperty, Screen.width, Screen.height, kCameraDepthBufferBits,
-                        FilterMode.Bilinear, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Default, m_Asset.MSAASampleCount);
-                    cmd.SetRenderTarget(m_CameraRTID);
+                    m_IntermediateTextureArray = false;
+                    if (stereoEnabled)
+                    {
+                        RenderTextureDescriptor xrDesc = XRSettings.eyeTextureDesc;
+                        xrDesc.depthBufferBits = kCameraDepthBufferBits;
+                        xrDesc.colorFormat = RenderTextureFormat.ARGB32;
+                        xrDesc.msaaSamples = m_Asset.MSAASampleCount;
+
+                        m_IntermediateTextureArray = (xrDesc.dimension == TextureDimension.Tex2DArray);
+
+                        cmd.GetTemporaryRT(m_CameraRTProperty, xrDesc, FilterMode.Bilinear);
+                    }
+                    else
+                    {
+                        cmd.GetTemporaryRT(m_CameraRTProperty, Screen.width, Screen.height, kCameraDepthBufferBits,
+                            FilterMode.Bilinear, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Default, m_Asset.MSAASampleCount);
+                    }
+
+                    if (m_IntermediateTextureArray)
+                        cmd.SetRenderTarget(m_CameraRTID, 0, CubemapFace.Unknown, -1);
+                    else
+                        cmd.SetRenderTarget(m_CameraRTID);
                 }
                 else
                 {
@@ -577,7 +603,7 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             }
             else
             {
-                cmd.SetRenderTarget(BuiltinRenderTextureType.None);
+                cmd.SetRenderTarget(BuiltinRenderTextureType.CurrentActive);
             }
 
             // Clear RenderTarget to avoid tile initialization on mobile GPUs
@@ -589,17 +615,30 @@ namespace UnityEngine.Experimental.Rendering.LightweightPipeline
             CommandBufferPool.Release(cmd);
         }
 
-        private void EndForwardRendering(Camera camera, ref ScriptableRenderContext context)
+        private void EndForwardRendering(Camera camera, ref ScriptableRenderContext context, bool stereoEnabled)
         {
-            if (!m_RenderToIntermediateTarget)
-                return;
+            if (m_RenderToIntermediateTarget)
+            {
+                var cmd = CommandBufferPool.Get("Blit");
+                if (m_IntermediateTextureArray)
+                {
+                    cmd.SetRenderTarget(BuiltinRenderTextureType.CameraTarget, 0, CubemapFace.Unknown, -1);
+                    cmd.Blit(m_CameraRTID, BuiltinRenderTextureType.CurrentActive);
+                }
+                else
+                    cmd.Blit(BuiltinRenderTextureType.CurrentActive, BuiltinRenderTextureType.CameraTarget);
 
-            var cmd = CommandBufferPool.Get("Blit");
-            cmd.Blit(BuiltinRenderTextureType.CurrentActive, BuiltinRenderTextureType.CameraTarget);
-            if (camera.cameraType == CameraType.SceneView)
-                cmd.SetRenderTarget(BuiltinRenderTextureType.CameraTarget);
-            context.ExecuteCommandBuffer(cmd);
-            CommandBufferPool.Release(cmd);
+                if (camera.cameraType == CameraType.SceneView)
+                    cmd.SetRenderTarget(BuiltinRenderTextureType.CameraTarget);
+                context.ExecuteCommandBuffer(cmd);
+                CommandBufferPool.Release(cmd);
+            }
+
+            if (stereoEnabled)
+            {
+                context.StopMultiEye(camera);
+                context.StereoEndRender(camera);
+            }
         }
 
         private bool GetRenderToIntermediateTarget(Camera camera)

--- a/Assets/ScriptableRenderPipeline/LightweightPipeline/Shaders/LightweightPipeline.shader
+++ b/Assets/ScriptableRenderPipeline/LightweightPipeline/Shaders/LightweightPipeline.shader
@@ -73,6 +73,7 @@ Shader "ScriptableRenderPipeline/LightweightPipeline/NonPBR"
             #pragma shader_feature _EMISSION
             #pragma shader_feature _ _REFLECTION_CUBEMAP _REFLECTION_PROBE
 
+            #pragma multi_compile _ UNITY_SINGLE_PASS_STEREO STEREO_INSTANCING_ON STEREO_MULTIVIEW_ON
             #pragma multi_compile _ _SINGLE_DIRECTIONAL_LIGHT
             #pragma multi_compile _ LIGHTMAP_ON
             #pragma multi_compile _ _LIGHT_PROBES_ON
@@ -90,6 +91,9 @@ Shader "ScriptableRenderPipeline/LightweightPipeline/NonPBR"
             v2f vert(LightweightVertexInput v)
             {
                 v2f o = (v2f)0;
+
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
                 o.uv01.xy = TRANSFORM_TEX(v.texcoord, _MainTex);
                 o.uv01.zw = v.lightmapUV * unity_LightmapST.xy + unity_LightmapST.zw;

--- a/Assets/ScriptableRenderPipeline/LightweightPipeline/Shaders/LightweightPipelineCore.cginc
+++ b/Assets/ScriptableRenderPipeline/LightweightPipeline/Shaders/LightweightPipelineCore.cginc
@@ -41,6 +41,7 @@ struct LightweightVertexInput
     float4 tangent : TANGENT;
     float3 texcoord : TEXCOORD0;
     float2 lightmapUV : TEXCOORD1;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
 struct v2f
@@ -57,6 +58,7 @@ struct v2f
     half4 viewDir : TEXCOORD5; // xyz: viewDir
     UNITY_FOG_COORDS_PACKED(6, half4) // x: fogCoord, yzw: vertexColor
     float4 hpos : SV_POSITION;
+    UNITY_VERTEX_OUTPUT_STEREO
 };
 
 // Per object light list data

--- a/Assets/ScriptableRenderPipeline/LightweightPipeline/Shaders/LightweightUnlit.shader
+++ b/Assets/ScriptableRenderPipeline/LightweightPipeline/Shaders/LightweightUnlit.shader
@@ -25,6 +25,7 @@
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag
+            #pragma multi_compile _ UNITY_SINGLE_PASS_STEREO STEREO_INSTANCING_ON STEREO_MULTIVIEW_ON
             #pragma multi_compile_fog
             #pragma shader_feature _ _ALPHATEST_ON _ALPHABLEND_ON
 
@@ -34,6 +35,7 @@
             {
                 float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
             };
 
             struct v2f
@@ -41,6 +43,7 @@
                 float2 uv : TEXCOORD0;
                 UNITY_FOG_COORDS(1)
                 float4 vertex : SV_POSITION;
+                UNITY_VERTEX_OUTPUT_STEREO
             };
 
             sampler2D _MainTex;
@@ -51,6 +54,10 @@
             v2f vert(appdata v)
             {
                 v2f o;
+
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.uv = TRANSFORM_TEX(v.uv, _MainTex);
                 UNITY_TRANSFER_FOG(o,o.vertex);


### PR DESCRIPTION
Similarly to PR #362 (Add XR Support to BasicRenderPipeline), this is using the new XR API in SRP to add XR rendering to LightweightPipeline.

The usage is relatively straightfoward (set up stereo properties, stereo-aware cull, bracket rendering APIs with stereo multiplexing, add stereo bits to shaders, stereo-aware intermediate target generation).

I did have to make some accommodations due to the current inefficiencies we have in managing texture array render textures (such as changing the release point of the temporary RTs to be after rendering is completed), but nothing too serious.

I tested this with the LDRenderPipelineBasicScene and LDRenderPipelineVikingVillage.  I used Single Pass and Single Pass Instanced, with the Mock HMD and Oculus Rift.