### PR TITLE
Branch litandlayeredimprovements

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -58,15 +58,25 @@ Shader "HDRenderPipeline/LayeredLit"
         _HeightMap2("HeightMap2", 2D) = "black" {}
         _HeightMap3("HeightMap3", 2D) = "black" {}
 
-        _HeightAmplitude0("Height Scale0", Float) = 1
-        _HeightAmplitude1("Height Scale1", Float) = 1
-        _HeightAmplitude2("Height Scale2", Float) = 1
-        _HeightAmplitude3("Height Scale3", Float) = 1
+        [HideInInspector] _HeightAmplitude0("Height Scale0", Float) = 1
+        [HideInInspector] _HeightAmplitude1("Height Scale1", Float) = 1
+        [HideInInspector] _HeightAmplitude2("Height Scale2", Float) = 1
+        [HideInInspector] _HeightAmplitude3("Height Scale3", Float) = 1
 
         _HeightCenter0("Height Bias0", Range(0.0, 1.0)) = 0.5
         _HeightCenter1("Height Bias1", Range(0.0, 1.0)) = 0.5
         _HeightCenter2("Height Bias2", Range(0.0, 1.0)) = 0.5
         _HeightCenter3("Height Bias3", Range(0.0, 1.0)) = 0.5
+
+        _HeightMin0("Height Min0", Float) = -1
+        _HeightMin1("Height Min1", Float) = -1
+        _HeightMin2("Height Min2", Float) = -1
+        _HeightMin3("Height Min3", Float) = -1
+
+        _HeightMax0("Height Max0", Float) = 1
+        _HeightMax1("Height Max1", Float) = 1
+        _HeightMax2("Height Max2", Float) = 1
+        _HeightMax3("Height Max3", Float) = 1
 
         _DetailMap0("DetailMap0", 2D) = "black" {}
         _DetailMap1("DetailMap1", 2D) = "black" {}

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -137,10 +137,10 @@ Shader "HDRenderPipeline/LayeredLit"
         _InheritBaseColor2("_InheritBaseColor2", Range(0, 1.0)) = 0.0
         _InheritBaseColor3("_InheritBaseColor3", Range(0, 1.0)) = 0.0
 
-        _OpacityAsDensity0("_OpacityAsDensity0", Range(0, 1.0)) = 0.0
-        _OpacityAsDensity1("_OpacityAsDensity1", Range(0, 1.0)) = 0.0
-        _OpacityAsDensity2("_OpacityAsDensity2", Range(0, 1.0)) = 0.0
-        _OpacityAsDensity3("_OpacityAsDensity3", Range(0, 1.0)) = 0.0
+        [ToggleOff] _OpacityAsDensity0("_OpacityAsDensity0", Float) = 0.0
+        [ToggleOff] _OpacityAsDensity1("_OpacityAsDensity1", Float) = 0.0
+        [ToggleOff] _OpacityAsDensity2("_OpacityAsDensity2", Float) = 0.0
+        [ToggleOff] _OpacityAsDensity3("_OpacityAsDensity3", Float) = 0.0
 
         _LayerTilingBlendMask("_LayerTilingBlendMask", Float) = 1
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -137,10 +137,10 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         _InheritBaseColor2("_InheritBaseColor2", Range(0, 1.0)) = 0.0
         _InheritBaseColor3("_InheritBaseColor3", Range(0, 1.0)) = 0.0
 
-        _OpacityAsDensity0("_OpacityAsDensity0", Range(0, 1.0)) = 0.0
-        _OpacityAsDensity1("_OpacityAsDensity1", Range(0, 1.0)) = 0.0
-        _OpacityAsDensity2("_OpacityAsDensity2", Range(0, 1.0)) = 0.0
-        _OpacityAsDensity3("_OpacityAsDensity3", Range(0, 1.0)) = 0.0
+        [ToggleOff] _OpacityAsDensity0("_OpacityAsDensity0", Float) = 0.0
+        [ToggleOff] _OpacityAsDensity1("_OpacityAsDensity1", Float) = 0.0
+        [ToggleOff] _OpacityAsDensity2("_OpacityAsDensity2", Float) = 0.0
+        [ToggleOff] _OpacityAsDensity3("_OpacityAsDensity3", Float) = 0.0
 
         _LayerTilingBlendMask("_LayerTilingBlendMask", Float) = 1
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -58,15 +58,25 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         _HeightMap2("HeightMap2", 2D) = "black" {}
         _HeightMap3("HeightMap3", 2D) = "black" {}
 
-        _HeightAmplitude0("Height Scale0", Float) = 1
-        _HeightAmplitude1("Height Scale1", Float) = 1
-        _HeightAmplitude2("Height Scale2", Float) = 1
-        _HeightAmplitude3("Height Scale3", Float) = 1
+        [HideInInspector] _HeightAmplitude0("Height Scale0", Float) = 1
+        [HideInInspector] _HeightAmplitude1("Height Scale1", Float) = 1
+        [HideInInspector] _HeightAmplitude2("Height Scale2", Float) = 1
+        [HideInInspector] _HeightAmplitude3("Height Scale3", Float) = 1
 
         _HeightCenter0("Height Bias0", Range(0.0, 1.0)) = 0.5
         _HeightCenter1("Height Bias1", Range(0.0, 1.0)) = 0.5
         _HeightCenter2("Height Bias2", Range(0.0, 1.0)) = 0.5
         _HeightCenter3("Height Bias3", Range(0.0, 1.0)) = 0.5
+
+        _HeightMin0("Height Min0", Float) = -1
+        _HeightMin1("Height Min1", Float) = -1
+        _HeightMin2("Height Min2", Float) = -1
+        _HeightMin3("Height Min3", Float) = -1
+
+        _HeightMax0("Height Max0", Float) = 1
+        _HeightMax1("Height Max1", Float) = 1
+        _HeightMax2("Height Max2", Float) = 1
+        _HeightMax3("Height Max3", Float) = 1
 
         _DetailMap0("DetailMap0", 2D) = "black" {}
         _DetailMap1("DetailMap1", 2D) = "black" {}

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
@@ -26,9 +26,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public static GUIContent normalMapOSText = new GUIContent("Normal Map OS", "Normal Map (BC7/DXT1/RGB)");
             public static GUIContent specularOcclusionMapText = new GUIContent("Specular Occlusion Map (RGBA)", "Specular Occlusion Map");
 
-            public static GUIContent heightMapText = new GUIContent("Height Map (R)", "Height Map");
-            public static GUIContent heightMapAmplitudeText = new GUIContent("Height Map Amplitude", "Height Map amplitude in world units (distance between minimum and maximum value in the texture).");
+            public static GUIContent heightMapText = new GUIContent("Height Map (R)", "Height Map.\nFor floating point textures, min, max and base value should be 0, 1 and 0.");
             public static GUIContent heightMapCenterText = new GUIContent("Height Map Base", "Base of the heightmap in the texture (between 0 and 1)");
+            public static GUIContent heightMapMinText = new GUIContent("Height Min", "Minimum value in the heightmap (in world units)");
+            public static GUIContent heightMapMaxText = new GUIContent("Height Max", "Maximum value in the heightmap (in world units)");
 
             public static GUIContent tangentMapText = new GUIContent("Tangent Map", "Tangent Map (BC7/BC5/DXT5(nm))");
             public static GUIContent tangentMapOSText = new GUIContent("Tangent Map OS", "Tangent Map (BC7/DXT1/RGB)");
@@ -145,6 +146,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected const string kHeightAmplitude = "_HeightAmplitude";
         protected MaterialProperty[] heightCenter = new MaterialProperty[kMaxLayerCount];
         protected const string kHeightCenter = "_HeightCenter";
+        protected MaterialProperty[] heightMin = new MaterialProperty[kMaxLayerCount];
+        protected const string kHeightMin = "_HeightMin";
+        protected MaterialProperty[] heightMax = new MaterialProperty[kMaxLayerCount];
+        protected const string kHeightMax = "_HeightMax";
 
         protected MaterialProperty[] UVDetail = new MaterialProperty[kMaxLayerCount];
         protected const string kUVDetail = "_UVDetail";
@@ -222,6 +227,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 normalMapSpace[i] = FindProperty(string.Format("{0}{1}", kNormalMapSpace, m_PropertySuffixes[i]), props);
                 heightMap[i] = FindProperty(string.Format("{0}{1}", kHeightMap, m_PropertySuffixes[i]), props);
                 heightAmplitude[i] = FindProperty(string.Format("{0}{1}", kHeightAmplitude, m_PropertySuffixes[i]), props);
+                heightMin[i] = FindProperty(string.Format("{0}{1}", kHeightMin, m_PropertySuffixes[i]), props);
+                heightMax[i] = FindProperty(string.Format("{0}{1}", kHeightMax, m_PropertySuffixes[i]), props);
                 heightCenter[i] = FindProperty(string.Format("{0}{1}", kHeightCenter, m_PropertySuffixes[i]), props);
 
                 // Details
@@ -400,8 +407,9 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             if (!heightMap[layerIndex].hasMixedValue && heightMap[layerIndex].textureValue != null)
             {
                 EditorGUI.indentLevel++;
-                m_MaterialEditor.ShaderProperty(heightAmplitude[layerIndex], Styles.heightMapAmplitudeText);
-                heightAmplitude[layerIndex].floatValue = Math.Max(0.0f, heightAmplitude[layerIndex].floatValue); // Must be positive
+                m_MaterialEditor.ShaderProperty(heightMin[layerIndex], Styles.heightMapMinText);
+                m_MaterialEditor.ShaderProperty(heightMax[layerIndex], Styles.heightMapMaxText);
+                heightAmplitude[layerIndex].floatValue = heightMax[layerIndex].floatValue - heightMin[layerIndex].floatValue;
                 m_MaterialEditor.ShaderProperty(heightCenter[layerIndex], Styles.heightMapCenterText);
                 EditorGUI.showMixedValue = false;
                 EditorGUI.indentLevel--;

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
@@ -20,7 +20,9 @@ Shader "HDRenderPipeline/Lit"
         _NormalScale("_NormalScale", Range(0.0, 2.0)) = 1
 
         _HeightMap("HeightMap", 2D) = "black" {}
-        _HeightAmplitude("Height Amplitude", Float) = 0.01 // In world units
+        [HideInInspector] _HeightAmplitude("Height Amplitude", Float) = 0.01 // In world units. This will be computed in the UI.
+        _HeightMin("Heightmap Min", Float) = -1
+        _HeightMax("Heightmap Max", Float) = 1
         _HeightCenter("Height Center", Range(0.0, 1.0)) = 0.5 // In texture space
 
         _DetailMap("DetailMap", 2D) = "black" {}

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
@@ -1232,10 +1232,9 @@ float3 ComputeMainNormalInfluence(float influenceMask, FragInputs input, float3 
 
     // THen get Main Layer Normal influence factor. Main layer is 0 because it can't be influence. In this case the final lerp return normalTS.
     float influenceFactor = BlendLayeredScalar(0.0, _InheritBaseNormal1, _InheritBaseNormal2, _InheritBaseNormal3, weights) * influenceMask;
-    // We will add smoothly the contribution of the normal map by using lower mips with help of bias sampling. InfluenceFactor must be [0..numMips] // Caution it cause banding...
+    // We will add smoothly the contribution of the normal map by lerping between vertex normal ( (0,0,1) in tangent space) and the actual normal from the main layer depending on the influence factor.
     // Note: that we don't take details map into account here.
-    float maxMipBias = log2(max(_NormalMap0_TexelSize.z, _NormalMap0_TexelSize.w)); // don't do + 1 as it is for bias, not lod
-    float3 mainNormalTS = GetNormalTS0(input, layerTexCoord, float3(0.0, 0.0, 1.0), 0.0, true, maxMipBias * (1.0 - influenceFactor));
+    float3 mainNormalTS = lerp(float3(0.0, 0.0, 1.0), normalTS0, influenceFactor);
 
     // Add on our regular normal a bit of Main Layer normal base on influence factor. Note that this affect only the "visible" normal.
     #ifdef SURFACE_GRADIENT

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
@@ -1241,15 +1241,15 @@ float3 ComputeMainNormalInfluence(float influenceMask, FragInputs input, float3 
     #ifdef SURFACE_GRADIENT
     return normalTS + influenceFactor * mainNormalTS * inputMainLayerMask;
     #else
-    return lerp(normalTS, BlendNormalRNM(normalTS, mainNormalTS), influenceFactor * inputMainLayerMask);
+    return lerp(normalTS, BlendNormalRNM(normalTS, mainNormalTS), influenceFactor * inputMainLayerMask); // Multiply by inputMainLayerMask in order to avoid influence where main layer should never be present
     #endif
 }
 
-float3 ComputeMainBaseColorInfluence(float influenceMask, float3 baseColor0, float3 baseColor1, float3 baseColor2, float3 baseColor3, LayerTexCoord layerTexCoord, float weights[_MAX_LAYER])
+float3 ComputeMainBaseColorInfluence(float influenceMask, float3 baseColor0, float3 baseColor1, float3 baseColor2, float3 baseColor3, LayerTexCoord layerTexCoord, float inputMainLayerMask, float weights[_MAX_LAYER])
 {
     float3 baseColor = BlendLayeredVector3(baseColor0, baseColor1, baseColor2, baseColor3, weights);
 
-    float influenceFactor = BlendLayeredScalar(0.0, _InheritBaseColor1, _InheritBaseColor2, _InheritBaseColor3, weights) * influenceMask;
+    float influenceFactor = BlendLayeredScalar(0.0, _InheritBaseColor1, _InheritBaseColor2, _InheritBaseColor3, weights) * influenceMask * inputMainLayerMask; // Multiply by inputMainLayerMask in order to avoid influence where main layer should never be present
 
     // We want to calculate the mean color of the texture. For this we will sample a low mipmap
     float textureBias = 15.0; // Use maximum bias
@@ -1315,7 +1315,7 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 #if defined(_MAIN_LAYER_INFLUENCE_MODE)
     if (influenceMask > 0.0f)
     {
-        surfaceData.baseColor = ComputeMainBaseColorInfluence(influenceMask, surfaceData0.baseColor, surfaceData1.baseColor, surfaceData2.baseColor, surfaceData3.baseColor, layerTexCoord, weights);
+        surfaceData.baseColor = ComputeMainBaseColorInfluence(influenceMask, surfaceData0.baseColor, surfaceData1.baseColor, surfaceData2.baseColor, surfaceData3.baseColor, layerTexCoord, blendMasks.a, weights);
         normalTS = ComputeMainNormalInfluence(influenceMask, input, normalTS0, normalTS1, normalTS2, normalTS3, layerTexCoord, blendMasks.a, weights);
     }
     else

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
@@ -1193,6 +1193,14 @@ void ComputeLayerWeights(FragInputs input, LayerTexCoord layerTexCoord, float4 i
         outWeights[i] = 0.0f;
     }
 
+    
+#if defined(_DENSITY_MODE)
+    // Note: blendMasks.argb because a is main layer
+    float4 opacityAsDensity = saturate((inputAlphaMask - (float4(1.0, 1.0, 1.0, 1.0) - blendMasks.argb)) * 20.0); // 20.0 is the number of steps in inputAlphaMask (Density mask. We decided 20 empirically)
+    float4 useOpacityAsDensityParam = float4(_OpacityAsDensity0, _OpacityAsDensity1, _OpacityAsDensity2, _OpacityAsDensity3);
+    blendMasks.argb = lerp(blendMasks.argb, opacityAsDensity, useOpacityAsDensityParam);
+#endif
+
 #if defined(_HEIGHT_BASED_BLEND)
 
 #if defined(_HEIGHTMAP0) || defined(_HEIGHTMAP1) || defined(_HEIGHTMAP2) || defined(_HEIGHTMAP3)
@@ -1212,13 +1220,6 @@ void ComputeLayerWeights(FragInputs input, LayerTexCoord layerTexCoord, float4 i
     blendMasks = ApplyHeightBlend(heights, blendMasks);
 #endif
     // If no heightmap is set on any layer, we don't need to try and blend them based on height...
-#endif
-
-#if defined(_DENSITY_MODE)
-    // Note: blendMasks.argb because a is main layer
-    float4 opacityAsDensity = saturate((inputAlphaMask - (float4(1.0, 1.0, 1.0, 1.0) - blendMasks.argb)) * 20.0); // 20.0 is the number of steps in inputAlphaMask (Density mask. We decided 20 empirically)
-    float4 useOpacityAsDensityParam = float4(_OpacityAsDensity0, _OpacityAsDensity1, _OpacityAsDensity2, _OpacityAsDensity3);
-    blendMasks.argb = lerp(blendMasks.argb, opacityAsDensity, useOpacityAsDensityParam);
 #endif
 
     ComputeMaskWeights(blendMasks, outWeights);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -20,8 +20,10 @@ Shader "HDRenderPipeline/LitTessellation"
         _NormalScale("_NormalScale", Range(0.0, 2.0)) = 1
 
         _HeightMap("HeightMap", 2D) = "black" {}
-        _HeightAmplitude("Height Amplitude", Float) = 0.01 // In world units
+        [HideInInspector] _HeightAmplitude("Height Amplitude", Float) = 0.01 // In world units
         _HeightCenter("Height Center", Range(0.0, 1.0)) = 0.5 // In texture space
+        _HeightMin("Heightmap Min", Float) = -1
+        _HeightMax("Heightmap Max", Float) = 1
 
         _DetailMap("DetailMap", 2D) = "black" {}
         _DetailMask("DetailMask", 2D) = "white" {}


### PR DESCRIPTION
Various Fix/improvement to layer and lit shader.
- Heightmap are now parametrized by min/max value instead of amplitude
- Opacity as Density is now a checkbox
- Influence Normal now uses vertex normal instead of lower mip normal
- Fixed a bug where base color inflence would show up even though main layer blend mask is zero