### PR TITLE
Removed DetailMask and Emissive Mode.

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/Editor/LayeredLitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/Editor/LayeredLitUI.cs
@@ -341,7 +341,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
 
 
-            DoLayerGUI(material, false, layerIndex);
+            DoLayerGUI(material, layerIndex);
 
             if (layerIndex == 0)
                 EditorGUILayout.Space();
@@ -627,12 +627,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             }
 
             bool layerChanged = DoLayersGUI(materialImporter);
-
-            EditorGUILayout.Space();
-            GUILayout.Label(Styles.lightingText, EditorStyles.boldLabel);
-            EditorGUI.indentLevel++;
-            m_MaterialEditor.TexturePropertySingleLine(Styles.emissiveText, emissiveColorMap, emissiveColor);
-            m_MaterialEditor.ShaderProperty(emissiveIntensity, Styles.emissiveIntensityText);
+            DoEmissiveGUI();
             DoEmissionArea(material);
             EditorGUI.indentLevel--;
             m_MaterialEditor.EnableInstancingField();

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -83,11 +83,6 @@ Shader "HDRenderPipeline/LayeredLit"
         _DetailMap2("DetailMap2", 2D) = "black" {}
         _DetailMap3("DetailMap3", 2D) = "black" {}
 
-        _DetailMask0("DetailMask0", 2D) = "white" {}
-        _DetailMask1("DetailMask1", 2D) = "white" {}
-        _DetailMask2("DetailMask2", 2D) = "white" {}
-        _DetailMask3("DetailMask3", 2D) = "white" {}
-
         _DetailAlbedoScale0("_DetailAlbedoScale0", Range(-2.0, 2.0)) = 1
         _DetailAlbedoScale1("_DetailAlbedoScale1", Range(-2.0, 2.0)) = 1
         _DetailAlbedoScale2("_DetailAlbedoScale2", Range(-2.0, 2.0)) = 1
@@ -167,6 +162,7 @@ Shader "HDRenderPipeline/LayeredLit"
         _EmissiveColor("EmissiveColor", Color) = (0, 0, 0)
         _EmissiveColorMap("EmissiveColorMap", 2D) = "white" {}
         _EmissiveIntensity("EmissiveIntensity", Float) = 0
+        [ToggleOff] _AlbedoAffectEmissive("Albedo Affect Emissive", Float) = 0.0
 
         [ToggleOff] _DistortionEnable("Enable Distortion", Float) = 0.0
         [ToggleOff] _DistortionOnly("Distortion Only", Float) = 0.0
@@ -261,8 +257,7 @@ Shader "HDRenderPipeline/LayeredLit"
     #pragma shader_feature _NORMALMAP_TANGENT_SPACE2
     #pragma shader_feature _NORMALMAP_TANGENT_SPACE3
     #pragma shader_feature _ _REQUIRE_UV2 _REQUIRE_UV3
-    #pragma shader_feature _EMISSIVE_COLOR
-
+    
     #pragma shader_feature _NORMALMAP0
     #pragma shader_feature _NORMALMAP1
     #pragma shader_feature _NORMALMAP2

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -83,11 +83,6 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         _DetailMap2("DetailMap2", 2D) = "black" {}
         _DetailMap3("DetailMap3", 2D) = "black" {}
 
-        _DetailMask0("DetailMask0", 2D) = "white" {}
-        _DetailMask1("DetailMask1", 2D) = "white" {}
-        _DetailMask2("DetailMask2", 2D) = "white" {}
-        _DetailMask3("DetailMask3", 2D) = "white" {}
-
         _DetailAlbedoScale0("_DetailAlbedoScale0", Range(-2.0, 2.0)) = 1
         _DetailAlbedoScale1("_DetailAlbedoScale1", Range(-2.0, 2.0)) = 1
         _DetailAlbedoScale2("_DetailAlbedoScale2", Range(-2.0, 2.0)) = 1
@@ -167,6 +162,7 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         _EmissiveColor("EmissiveColor", Color) = (0, 0, 0)
         _EmissiveColorMap("EmissiveColorMap", 2D) = "white" {}
         _EmissiveIntensity("EmissiveIntensity", Float) = 0
+        [ToggleOff] _AlbedoAffectEmissive("Albedo Affect Emissive", Float) = 0.0
 
         [ToggleOff] _DistortionEnable("Enable Distortion", Float) = 0.0
         [ToggleOff] _DistortionOnly("Distortion Only", Float) = 0.0
@@ -277,7 +273,6 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
     #pragma shader_feature _NORMALMAP_TANGENT_SPACE2
     #pragma shader_feature _NORMALMAP_TANGENT_SPACE3
     #pragma shader_feature _ _REQUIRE_UV2 _REQUIRE_UV3
-    #pragma shader_feature _EMISSIVE_COLOR
 
     #pragma shader_feature _NORMALMAP0
     #pragma shader_feature _NORMALMAP1

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
@@ -18,8 +18,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public static GUIContent smoothnessMapChannelText = new GUIContent("Smoothness Source", "Smoothness texture and channel");
             public static GUIContent metallicText = new GUIContent("Metallic", "Metallic scale factor");
             public static GUIContent smoothnessText = new GUIContent("Smoothness", "Smoothness scale factor");
-            public static GUIContent maskMapESText = new GUIContent("Mask Map - M(R), AO(G), E(B), S(A)", "Mask map");
-            public static GUIContent maskMapSText = new GUIContent("Mask Map - M(R), AO(G), S(A)", "Mask map");
+            public static GUIContent maskMapSText = new GUIContent("Mask Map - M(R), AO(G), D(B), S(A)", "Mask map");
 
             public static GUIContent normalMapSpaceText = new GUIContent("Normal Map space", "");
             public static GUIContent normalMapText = new GUIContent("Normal Map", "Normal Map (BC7/BC5/DXT5(nm))");
@@ -43,7 +42,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public static string detailText = "Detail Inputs";
             public static GUIContent UVDetailMappingText = new GUIContent("Detail UV mapping", "");
             public static GUIContent detailMapNormalText = new GUIContent("Detail Map A(R) Ny(G) S(B) Nx(A)", "Detail Map");
-            public static GUIContent detailMaskText = new GUIContent("Detail Mask (G)", "Mask for detailMap");
             public static GUIContent detailAlbedoScaleText = new GUIContent("Detail AlbedoScale", "Detail Albedo Scale factor");
             public static GUIContent detailNormalScaleText = new GUIContent("Detail NormalScale", "Normal Scale factor");
             public static GUIContent detailSmoothnessScaleText = new GUIContent("Detail SmoothnessScale", "Smoothness Scale factor");
@@ -66,7 +64,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public static string lightingText = "Lighting Inputs";
             public static GUIContent emissiveText = new GUIContent("Emissive Color", "Emissive");
             public static GUIContent emissiveIntensityText = new GUIContent("Emissive Intensity", "Emissive");
-            public static GUIContent emissiveColorModeText = new GUIContent("Emissive Color Usage", "Use emissive color or emissive mask");
+            public static GUIContent albedoAffectEmissiveText = new GUIContent("Albedo Affect Emissive", "Specifies whether or not the emissive color is multiplied by the albedo.");
 
             public static GUIContent normalMapSpaceWarning = new GUIContent("Object space normal can't be use with triplanar mapping.");
         }
@@ -105,12 +103,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             UV1,
             UV2,
             UV3
-        }
-
-        public enum EmissiveColorMode
-        {
-            UseEmissiveColor,
-            UseEmissiveMask,
         }
 
         protected MaterialProperty[] UVBase = new MaterialProperty[kMaxLayerCount];
@@ -157,8 +149,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected const string kUVDetailsMappingMask = "_UVDetailsMappingMask";
         protected MaterialProperty[] detailMap = new MaterialProperty[kMaxLayerCount];
         protected const string kDetailMap = "_DetailMap";
-        protected MaterialProperty[] detailMask = new MaterialProperty[kMaxLayerCount];
-        protected const string kDetailMask = "_DetailMask";
         protected MaterialProperty[] detailAlbedoScale = new MaterialProperty[kMaxLayerCount];
         protected const string kDetailAlbedoScale = "_DetailAlbedoScale";
         protected MaterialProperty[] detailNormalScale = new MaterialProperty[kMaxLayerCount];
@@ -205,7 +195,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected const string kEmissiveColorMap = "_EmissiveColorMap";
         protected MaterialProperty emissiveIntensity = null;
         protected const string kEmissiveIntensity = "_EmissiveIntensity";
-
+        protected MaterialProperty albedoAffectEmissive = null;
+        protected const string kAlbedoAffectEmissive = "_AlbedoAffectEmissive";
 
         protected void FindMaterialLayerProperties(MaterialProperty[] props)
         {
@@ -235,7 +226,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 UVDetail[i] = FindProperty(string.Format("{0}{1}", kUVDetail, m_PropertySuffixes[i]), props);
                 UVDetailsMappingMask[i] = FindProperty(string.Format("{0}{1}", kUVDetailsMappingMask, m_PropertySuffixes[i]), props);
                 detailMap[i] = FindProperty(string.Format("{0}{1}", kDetailMap, m_PropertySuffixes[i]), props);
-                detailMask[i] = FindProperty(string.Format("{0}{1}", kDetailMask, m_PropertySuffixes[i]), props);
                 detailAlbedoScale[i] = FindProperty(string.Format("{0}{1}", kDetailAlbedoScale, m_PropertySuffixes[i]), props);
                 detailNormalScale[i] = FindProperty(string.Format("{0}{1}", kDetailNormalScale, m_PropertySuffixes[i]), props);
                 detailSmoothnessScale[i] = FindProperty(string.Format("{0}{1}", kDetailSmoothnessScale, m_PropertySuffixes[i]), props);
@@ -248,6 +238,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             emissiveColor = FindProperty(kEmissiveColor, props);
             emissiveColorMap = FindProperty(kEmissiveColorMap, props);
             emissiveIntensity = FindProperty(kEmissiveIntensity, props);
+            albedoAffectEmissive = FindProperty(kAlbedoAffectEmissive, props);
         }
 
         protected override void FindMaterialProperties(MaterialProperty[] props)
@@ -355,7 +346,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             m_MaterialEditor.TexturePropertySingleLine(Styles.anisotropyMapText, anisotropyMap);
         }
 
-        protected void DoLayerGUI(Material material, bool useEmissiveMask, int layerIndex)
+        protected void DoLayerGUI(Material material, int layerIndex)
         {
             EditorGUILayout.LabelField(Styles.InputsText, EditorStyles.boldLabel);
 
@@ -375,10 +366,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             m_MaterialEditor.ShaderProperty(smoothness[layerIndex], Styles.smoothnessText);
 
-            if (useEmissiveMask)
-                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapESText, maskMap[layerIndex]);
-            else
-                m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapSText, maskMap[layerIndex]);
+            m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapSText, maskMap[layerIndex]);
 
             m_MaterialEditor.TexturePropertySingleLine(Styles.specularOcclusionMapText, specularOcclusionMap[layerIndex]);
 
@@ -464,7 +452,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUILayout.LabelField(Styles.detailText, EditorStyles.boldLabel);
 
             EditorGUI.indentLevel++;
-            m_MaterialEditor.TexturePropertySingleLine(Styles.detailMaskText, detailMask[layerIndex]);
             m_MaterialEditor.TexturePropertySingleLine(Styles.detailMapNormalText, detailMap[layerIndex]);
 
             // When Planar or Triplanar is enable the UVDetail use the same mode, so we disable the choice on UVDetail
@@ -496,26 +483,22 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             EditorGUI.indentLevel--;
         }
 
-        protected override void MaterialPropertiesGUI(Material material)
+        protected void DoEmissiveGUI()
         {
-            bool useEmissiveMask = (EmissiveColorMode)emissiveColorMode.floatValue == EmissiveColorMode.UseEmissiveMask;
-
-            DoLayerGUI(material, useEmissiveMask, 0);
-
             EditorGUILayout.Space();
             EditorGUILayout.LabelField(Styles.lightingText, EditorStyles.boldLabel);
 
             EditorGUI.indentLevel++;
-            m_MaterialEditor.ShaderProperty(emissiveColorMode, Styles.emissiveColorModeText);
-
-            if (!useEmissiveMask)
-            {
-                m_MaterialEditor.TexturePropertySingleLine(Styles.emissiveText, emissiveColorMap, emissiveColor);
-            }
-
+            m_MaterialEditor.TexturePropertySingleLine(Styles.emissiveText, emissiveColorMap, emissiveColor);
             m_MaterialEditor.ShaderProperty(emissiveIntensity, Styles.emissiveIntensityText);
-
+            m_MaterialEditor.ShaderProperty(albedoAffectEmissive, Styles.albedoAffectEmissiveText);
             EditorGUI.indentLevel--;
+        }
+
+        protected override void MaterialPropertiesGUI(Material material)
+        {
+            DoLayerGUI(material, 0);
+            DoEmissiveGUI();
             // The parent Base.ShaderPropertiesGUI will call DoEmissionArea
         }
 
@@ -542,7 +525,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             SetKeyword(material, "_MAPPING_PLANAR", ((UVBaseMapping)material.GetFloat(kUVBase)) == UVBaseMapping.Planar);
             SetKeyword(material, "_MAPPING_TRIPLANAR", ((UVBaseMapping)material.GetFloat(kUVBase)) == UVBaseMapping.Triplanar);
             SetKeyword(material, "_NORMALMAP_TANGENT_SPACE", (normalMapSpace == NormalMapSpace.TangentSpace));
-            SetKeyword(material, "_EMISSIVE_COLOR", ((EmissiveColorMode)material.GetFloat(kEmissiveColorMode)) == EmissiveColorMode.UseEmissiveColor);
 
             if (normalMapSpace == NormalMapSpace.TangentSpace)
             {

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
@@ -26,7 +26,6 @@ Shader "HDRenderPipeline/Lit"
         _HeightCenter("Height Center", Range(0.0, 1.0)) = 0.5 // In texture space
 
         _DetailMap("DetailMap", 2D) = "black" {}
-        _DetailMask("DetailMask", 2D) = "white" {}
         _DetailAlbedoScale("_DetailAlbedoScale", Range(-2.0, 2.0)) = 1
         _DetailNormalScale("_DetailNormalScale", Range(0.0, 2.0)) = 1
         _DetailSmoothnessScale("_DetailSmoothnessScale", Range(-2.0, 2.0)) = 1
@@ -64,6 +63,7 @@ Shader "HDRenderPipeline/Lit"
         _EmissiveColor("EmissiveColor", Color) = (0, 0, 0)
         _EmissiveColorMap("EmissiveColorMap", 2D) = "white" {}
         _EmissiveIntensity("EmissiveIntensity", Float) = 0
+        [ToggleOff] _AlbedoAffectEmissive("Albedo Affect Emissive", Float) = 0.0
 
         [ToggleOff] _DistortionEnable("Enable Distortion", Float) = 0.0
         [ToggleOff] _DistortionOnly("Distortion Only", Float) = 0.0
@@ -133,7 +133,6 @@ Shader "HDRenderPipeline/Lit"
     #pragma shader_feature _ _MAPPING_PLANAR _MAPPING_TRIPLANAR
     #pragma shader_feature _NORMALMAP_TANGENT_SPACE
     #pragma shader_feature _ _REQUIRE_UV2 _REQUIRE_UV3
-    #pragma shader_feature _EMISSIVE_COLOR
 
     #pragma shader_feature _NORMALMAP
     #pragma shader_feature _MASKMAP

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
@@ -30,18 +30,9 @@ void GetBuiltinData(FragInputs input, SurfaceData surfaceData, float alpha, floa
     // Emissive Intensity is only use here, but is part of BuiltinData to enforce UI parameters as we want the users to fill one color and one intensity
     builtinData.emissiveIntensity = _EmissiveIntensity; // We still store intensity here so we can reuse it with debug code
 
-    // If we chose an emissive color, we have a dedicated texture for it and don't use MaskMap
-#ifdef _EMISSIVE_COLOR
+    builtinData.emissiveColor = _EmissiveColor * builtinData.emissiveIntensity * lerp(1.0, surfaceData.baseColor, _AlbedoAffectEmissive);
 #ifdef _EMISSIVE_COLOR_MAP
-    builtinData.emissiveColor = SAMPLE_TEXTURE2D(_EmissiveColorMap, sampler_EmissiveColorMap, input.texCoord0).rgb * _EmissiveColor * builtinData.emissiveIntensity;
-#else
-    builtinData.emissiveColor = _EmissiveColor * builtinData.emissiveIntensity;
-#endif
-// If we have a MaskMap, use emissive slot as a mask on baseColor
-#elif defined(_MASKMAP) && !defined(LAYERED_LIT_SHADER) // With layered lit we have no emissive mask option
-    builtinData.emissiveColor = surfaceData.baseColor * (SAMPLE_TEXTURE2D(_MaskMap, sampler_MaskMap, input.texCoord0).b * builtinData.emissiveIntensity).xxx;
-#else
-    builtinData.emissiveColor = float3(0.0, 0.0, 0.0);
+    builtinData.emissiveColor *= SAMPLE_TEXTURE2D(_EmissiveColorMap, sampler_EmissiveColorMap, input.texCoord0).rgb;
 #endif
 
     builtinData.velocity = float2(0.0, 0.0);
@@ -134,7 +125,6 @@ void GenerateLayerTexCoordBasisTB(FragInputs input, inout LayerTexCoord layerTex
 #define SAMPLER_NORMALMAP_IDX sampler_NormalMapOS
 #endif
 
-#define SAMPLER_DETAILMASK_IDX sampler_DetailMask
 #define SAMPLER_DETAILMAP_IDX sampler_DetailMap
 #define SAMPLER_MASKMAP_IDX sampler_MaskMap
 #define SAMPLER_SPECULAROCCLUSIONMAP_IDX sampler_SpecularOcclusionMap
@@ -420,16 +410,12 @@ void GetSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInputs p
 #endif
 
 #if defined(_DETAIL_MAP0)
-#define SAMPLER_DETAILMASK_IDX sampler_DetailMask0
 #define SAMPLER_DETAILMAP_IDX sampler_DetailMap0
 #elif defined(_DETAIL_MAP1)
-#define SAMPLER_DETAILMASK_IDX sampler_DetailMask1
 #define SAMPLER_DETAILMAP_IDX sampler_DetailMap1
 #elif defined(_DETAIL_MAP2)
-#define SAMPLER_DETAILMASK_IDX sampler_DetailMask2
 #define SAMPLER_DETAILMAP_IDX sampler_DetailMap2
 #else
-#define SAMPLER_DETAILMASK_IDX sampler_DetailMask3
 #define SAMPLER_DETAILMAP_IDX sampler_DetailMap3
 #endif
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataInternal.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataInternal.hlsl
@@ -130,7 +130,10 @@ float ADD_IDX(GetSurfaceData)(FragInputs input, LayerTexCoord layerTexCoord, out
     float3 detailNormalTS = float3(0.0, 0.0, 0.0);
     float detailMask = 0.0;
 #ifdef _DETAIL_MAP_IDX
-    detailMask = SAMPLE_UVMAPPING_TEXTURE2D(ADD_IDX(_DetailMask), SAMPLER_DETAILMASK_IDX, ADD_IDX(layerTexCoord.base)).g;
+    detailMask = 1.0;
+    #ifdef _MASKMAP_IDX
+        detailMask = SAMPLE_UVMAPPING_TEXTURE2D(ADD_IDX(_MaskMap), SAMPLER_MASKMAP_IDX, ADD_IDX(layerTexCoord.base)).b;
+    #endif
     float2 detailAlbedoAndSmoothness = SAMPLE_UVMAPPING_TEXTURE2D(ADD_IDX(_DetailMap), SAMPLER_DETAILMAP_IDX, ADD_IDX(layerTexCoord.details)).rb;
     float detailAlbedo = detailAlbedoAndSmoothness.r;
     float detailSmoothness = detailAlbedoAndSmoothness.g;

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitProperties.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitProperties.hlsl
@@ -28,8 +28,6 @@ SAMPLER2D(sampler_NormalMap);
 TEXTURE2D(_NormalMapOS);
 SAMPLER2D(sampler_NormalMapOS);
 
-TEXTURE2D(_DetailMask);
-SAMPLER2D(sampler_DetailMask);
 TEXTURE2D(_DetailMap);
 SAMPLER2D(sampler_DetailMap);
 
@@ -75,7 +73,6 @@ PROP_DECL_TEX2D(_SpecularOcclusionMap);
 PROP_DECL_TEX2D(_NormalMap);
 PROP_DECL_TEX2D(_NormalMapOS);
 PROP_DECL_TEX2D(_HeightMap);
-PROP_DECL_TEX2D(_DetailMask);
 PROP_DECL_TEX2D(_DetailMap);
 
 TEXTURE2D(_LayerMaskMap);
@@ -98,6 +95,7 @@ float _PPDLodThreshold;
 
 float3 _EmissiveColor;
 float _EmissiveIntensity;
+float _AlbedoAffectEmissive;
 
 // Caution: C# code in BaseLitUI.cs call LightmapEmissionFlagsProperty() which assume that there is an existing "_EmissionColor"
 // value that exist to identify if the GI emission need to be enabled.

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -26,7 +26,6 @@ Shader "HDRenderPipeline/LitTessellation"
         _HeightMax("Heightmap Max", Float) = 1
 
         _DetailMap("DetailMap", 2D) = "black" {}
-        _DetailMask("DetailMask", 2D) = "white" {}
         _DetailAlbedoScale("_DetailAlbedoScale", Range(-2.0, 2.0)) = 1
         _DetailNormalScale("_DetailNormalScale", Range(0.0, 2.0)) = 1
         _DetailSmoothnessScale("_DetailSmoothnessScale", Range(-2.0, 2.0)) = 1
@@ -64,6 +63,7 @@ Shader "HDRenderPipeline/LitTessellation"
         _EmissiveColor("EmissiveColor", Color) = (0, 0, 0)
         _EmissiveColorMap("EmissiveColorMap", 2D) = "white" {}
         _EmissiveIntensity("EmissiveIntensity", Float) = 0
+        [ToggleOff] _AlbedoAffectEmissive("Albedo Affect Emissive", Float) = 0.0
 
         [ToggleOff] _DistortionEnable("Enable Distortion", Float) = 0.0
         [ToggleOff] _DistortionOnly("Distortion Only", Float) = 0.0
@@ -149,7 +149,6 @@ Shader "HDRenderPipeline/LitTessellation"
     #pragma shader_feature _ _MAPPING_PLANAR _MAPPING_TRIPLANAR
     #pragma shader_feature _NORMALMAP_TANGENT_SPACE
     #pragma shader_feature _ _REQUIRE_UV2 _REQUIRE_UV3
-    #pragma shader_feature _EMISSIVE_COLOR
 
     #pragma shader_feature _NORMALMAP
     #pragma shader_feature _MASKMAP

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/UnlitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Unlit/Editor/UnlitUI.cs
@@ -14,7 +14,6 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             public static GUIContent emissiveText = new GUIContent("Emissive Color", "Emissive");
             public static GUIContent emissiveIntensityText = new GUIContent("Emissive Intensity", "Emissive");
-            public static GUIContent emissiveColorModeText = new GUIContent("Emissive Color Usage", "Use emissive color or emissive mask");
         }
 
         protected MaterialProperty color = null;


### PR DESCRIPTION
- Detail mask is now always in the blue channel of the mask map
- Emissive is now EmissiveMap * EmissiveColor * lerp(1.0, Albedo, albedoAffectEmissive) with EmissiveMap being optional.