### PR TITLE
Branch litandlayeredimprovements

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/Editor/LayeredLitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/Editor/LayeredLitUI.cs
@@ -106,6 +106,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         const string kObjectScaleAffectTile = "_ObjectScaleAffectTile";
         MaterialProperty UVBlendMask = null;
         const string kUVBlendMask = "_UVBlendMask";
+        MaterialProperty UVMappingMaskBlendMask = null;
+        const string kUVMappingMaskBlendMask = "_UVMappingMaskBlendMask";
         MaterialProperty layerTilingBlendMask = null;
         const string kLayerTilingBlendMask = "_LayerTilingBlendMask";
         MaterialProperty texWorldScaleBlendMask = null;
@@ -148,6 +150,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             vertexColorMode = FindProperty(kVertexColorMode, props);
             objectScaleAffectTile = FindProperty(kObjectScaleAffectTile, props);
             UVBlendMask = FindProperty(kUVBlendMask, props);
+            UVMappingMaskBlendMask = FindProperty(kUVMappingMaskBlendMask, props);
             layerTilingBlendMask = FindProperty(kLayerTilingBlendMask, props);
             texWorldScaleBlendMask = FindProperty(kTexWorldScaleBlendMask, props);
 
@@ -374,6 +377,15 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             EditorGUI.indentLevel++;
             m_MaterialEditor.ShaderProperty(UVBlendMask, styles.UVBlendMaskText);
+            UVBaseMapping uvBlendMask = (UVBaseMapping)UVBlendMask.floatValue;
+
+            float X, Y, Z, W;
+            X = (uvBlendMask == UVBaseMapping.UV0) ? 1.0f : 0.0f;
+            Y = (uvBlendMask == UVBaseMapping.UV1) ? 1.0f : 0.0f;
+            Z = (uvBlendMask == UVBaseMapping.UV2) ? 1.0f : 0.0f;
+            W = (uvBlendMask == UVBaseMapping.UV3) ? 1.0f : 0.0f;
+
+            UVMappingMaskBlendMask.colorValue = new Color(X, Y, Z, W);
 
             if (((UVBaseMapping)UVBlendMask.floatValue == UVBaseMapping.Planar) ||
                 ((UVBaseMapping)UVBlendMask.floatValue == UVBaseMapping.Triplanar))

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -154,7 +154,8 @@ Shader "HDRenderPipeline/LayeredLit"
         [Enum(None, 0, Multiply, 1, Add, 2)] _VertexColorMode("Vertex color mode", Float) = 0
 
         [ToggleOff]  _ObjectScaleAffectTile("_ObjectScaleAffectTile", Float) = 0.0
-        [Enum(UV0, 0, Planar, 4, Triplanar, 5)] _UVBlendMask("UV Set for blendMask", Float) = 0
+        [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBlendMask("UV Set for blendMask", Float) = 0
+        [HideInInspector] _UVMappingMaskBlendMask("_UVMappingMaskBlendMask", Color) = (1, 0, 0, 0)
         _TexWorldScaleBlendMask("Tiling", Float) = 1.0
 
         // Following are builtin properties
@@ -218,7 +219,7 @@ Shader "HDRenderPipeline/LayeredLit"
         _TexWorldScale2("Tiling", Float) = 1.0
         _TexWorldScale3("Tiling", Float) = 1.0
 
-        [Enum(UV0, 0, Planar, 4, Triplanar, 5)] _UVBase0("UV Set for base0", Float) = 0 // no UV1/2/3 for main layer (matching Lit.shader and for PPDisplacement restriction)
+        [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBase0("UV Set for base0", Float) = 0 // no UV1/2/3 for main layer (matching Lit.shader and for PPDisplacement restriction)
         [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBase1("UV Set for base1", Float) = 0
         [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBase2("UV Set for base2", Float) = 0
         [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBase3("UV Set for base3", Float) = 0

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLit.shader
@@ -28,6 +28,16 @@ Shader "HDRenderPipeline/LayeredLit"
         _Smoothness2("Smoothness2", Range(0.0, 1.0)) = 1.0
         _Smoothness3("Smoothness3", Range(0.0, 1.0)) = 1.0
 
+        _SmoothnessRemapMin0("SmoothnessRemapMin0", Range(0.0, 1.0)) = 0.0
+        _SmoothnessRemapMin1("SmoothnessRemapMin1", Range(0.0, 1.0)) = 0.0
+        _SmoothnessRemapMin2("SmoothnessRemapMin2", Range(0.0, 1.0)) = 0.0
+        _SmoothnessRemapMin3("SmoothnessRemapMin3", Range(0.0, 1.0)) = 0.0
+
+        _SmoothnessRemapMax0("SmoothnessRemapMax0", Range(0.0, 1.0)) = 1.0
+        _SmoothnessRemapMax1("SmoothnessRemapMax1", Range(0.0, 1.0)) = 1.0
+        _SmoothnessRemapMax2("SmoothnessRemapMax2", Range(0.0, 1.0)) = 1.0
+        _SmoothnessRemapMax3("SmoothnessRemapMax3", Range(0.0, 1.0)) = 1.0
+
         _MaskMap0("MaskMap0", 2D) = "white" {}
         _MaskMap1("MaskMap1", 2D) = "white" {}
         _MaskMap2("MaskMap2", 2D) = "white" {}

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -154,7 +154,8 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         [Enum(None, 0, Multiply, 1, Add, 2)] _VertexColorMode("Vertex color mode", Float) = 0
 
         [ToggleOff]  _ObjectScaleAffectTile("_ObjectScaleAffectTile", Float) = 0.0
-        [Enum(UV0, 0, Planar, 4, Triplanar, 5)] _UVBlendMask("UV Set for blendMask", Float) = 0
+        [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBlendMask("UV Set for blendMask", Float) = 0
+        [HideInInspector] _UVMappingMaskBlendMask("_UVMappingMaskBlendMask", Color) = (1, 0, 0, 0)
         _TexWorldScaleBlendMask("Tiling", Float) = 1.0
 
         // Following are builtin properties
@@ -218,7 +219,7 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         _TexWorldScale2("Tiling", Float) = 1.0
         _TexWorldScale3("Tiling", Float) = 1.0
 
-        [Enum(UV0, 0, Planar, 4, Triplanar, 5)] _UVBase0("UV Set for base0", Float) = 0 // no UV1/2/3 for main layer (matching Lit.shader and for PPDisplacement restriction)
+        [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBase0("UV Set for base0", Float) = 0 // no UV1/2/3 for main layer (matching Lit.shader and for PPDisplacement restriction)
         [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBase1("UV Set for base1", Float) = 0
         [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBase2("UV Set for base2", Float) = 0
         [Enum(UV0, 0, UV1, 1, UV2, 2, UV3, 3, Planar, 4, Triplanar, 5)] _UVBase3("UV Set for base3", Float) = 0

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/LayeredLit/LayeredLitTessellation.shader
@@ -28,6 +28,16 @@ Shader "HDRenderPipeline/LayeredLitTessellation"
         _Smoothness2("Smoothness2", Range(0.0, 1.0)) = 1.0
         _Smoothness3("Smoothness3", Range(0.0, 1.0)) = 1.0
 
+        _SmoothnessRemapMin0("SmoothnessRemapMin0", Range(0.0, 1.0)) = 0.0
+        _SmoothnessRemapMin1("SmoothnessRemapMin1", Range(0.0, 1.0)) = 0.0
+        _SmoothnessRemapMin2("SmoothnessRemapMin2", Range(0.0, 1.0)) = 0.0
+        _SmoothnessRemapMin3("SmoothnessRemapMin3", Range(0.0, 1.0)) = 0.0
+
+        _SmoothnessRemapMax0("SmoothnessRemapMax0", Range(0.0, 1.0)) = 1.0
+        _SmoothnessRemapMax1("SmoothnessRemapMax1", Range(0.0, 1.0)) = 1.0
+        _SmoothnessRemapMax2("SmoothnessRemapMax2", Range(0.0, 1.0)) = 1.0
+        _SmoothnessRemapMax3("SmoothnessRemapMax3", Range(0.0, 1.0)) = 1.0
+
         _MaskMap0("MaskMap0", 2D) = "white" {}
         _MaskMap1("MaskMap1", 2D) = "white" {}
         _MaskMap2("MaskMap2", 2D) = "white" {}

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
@@ -18,6 +18,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             public static GUIContent smoothnessMapChannelText = new GUIContent("Smoothness Source", "Smoothness texture and channel");
             public static GUIContent metallicText = new GUIContent("Metallic", "Metallic scale factor");
             public static GUIContent smoothnessText = new GUIContent("Smoothness", "Smoothness scale factor");
+            public static GUIContent smoothnessRemappingText = new GUIContent("Smoothness Remapping", "Smoothness remapping");
             public static GUIContent maskMapSText = new GUIContent("Mask Map - M(R), AO(G), D(B), S(A)", "Mask map");
 
             public static GUIContent normalMapSpaceText = new GUIContent("Normal Map space", "");
@@ -120,6 +121,10 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
         protected const string kMetallic = "_Metallic";
         protected MaterialProperty[] smoothness = new MaterialProperty[kMaxLayerCount];
         protected const string kSmoothness = "_Smoothness";
+        protected MaterialProperty[] smoothnessRemapMin = new MaterialProperty[kMaxLayerCount];
+        protected const string kSmoothnessRemapMin = "_SmoothnessRemapMin";
+        protected MaterialProperty[] smoothnessRemapMax = new MaterialProperty[kMaxLayerCount];
+        protected const string kSmoothnessRemapMax = "_SmoothnessRemapMax";
         protected MaterialProperty[] maskMap = new MaterialProperty[kMaxLayerCount];
         protected const string kMaskMap = "_MaskMap";
         protected MaterialProperty[] specularOcclusionMap = new MaterialProperty[kMaxLayerCount];
@@ -210,6 +215,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 baseColorMap[i] = FindProperty(string.Format("{0}{1}", kBaseColorMap, m_PropertySuffixes[i]), props);
                 metallic[i] = FindProperty(string.Format("{0}{1}", kMetallic, m_PropertySuffixes[i]), props);
                 smoothness[i] = FindProperty(string.Format("{0}{1}", kSmoothness, m_PropertySuffixes[i]), props);
+                smoothnessRemapMin[i] = FindProperty(string.Format("{0}{1}", kSmoothnessRemapMin, m_PropertySuffixes[i]), props);
+                smoothnessRemapMax[i] = FindProperty(string.Format("{0}{1}", kSmoothnessRemapMax, m_PropertySuffixes[i]), props);
                 maskMap[i] = FindProperty(string.Format("{0}{1}", kMaskMap, m_PropertySuffixes[i]), props);
                 specularOcclusionMap[i] = FindProperty(string.Format("{0}{1}", kSpecularOcclusionMap, m_PropertySuffixes[i]), props);
                 normalMap[i] = FindProperty(string.Format("{0}{1}", kNormalMap, m_PropertySuffixes[i]), props);
@@ -364,7 +371,23 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 m_MaterialEditor.ShaderProperty(metallic[layerIndex], Styles.metallicText);
             }
 
-            m_MaterialEditor.ShaderProperty(smoothness[layerIndex], Styles.smoothnessText);
+            if(maskMap[layerIndex].textureValue == null)
+            {
+                m_MaterialEditor.ShaderProperty(smoothness[layerIndex], Styles.smoothnessText);
+
+            }
+            else
+            {
+                float remapMin = smoothnessRemapMin[layerIndex].floatValue;
+                float remapMax = smoothnessRemapMax[layerIndex].floatValue;
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.MinMaxSlider(Styles.smoothnessRemappingText, ref remapMin, ref remapMax, 0.0f, 1.0f);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    smoothnessRemapMin[layerIndex].floatValue = remapMin;
+                    smoothnessRemapMax[layerIndex].floatValue = remapMax;
+                }
+            }
 
             m_MaterialEditor.TexturePropertySingleLine(Styles.maskMapSText, maskMap[layerIndex]);
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
@@ -359,11 +359,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             EditorGUI.indentLevel++;
 
-            // indentation around base color is a workaround for a bug in material properties UI where the color picker is not indented properly and gets cropped (and unusable in layered shader UI)
-            // Remove when bug is fixed.
-            EditorGUI.indentLevel--;
             m_MaterialEditor.TexturePropertySingleLine(Styles.baseColorText, baseColorMap[layerIndex], baseColor[layerIndex]);
-            EditorGUI.indentLevel++;
 
             if ( materialID == null || // Will be the case for Layered materials where we only support standard and the parameter does not exist
                 (Lit.MaterialId)materialID.floatValue == Lit.MaterialId.LitStandard || (Lit.MaterialId)materialID.floatValue == Lit.MaterialId.LitAniso)
@@ -477,17 +473,17 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
             m_MaterialEditor.TexturePropertySingleLine(Styles.detailMapNormalText, detailMap[layerIndex]);
 
             // When Planar or Triplanar is enable the UVDetail use the same mode, so we disable the choice on UVDetail
-            if (uvBaseMapping == UVBaseMapping.UV0)
-            {
-                m_MaterialEditor.ShaderProperty(UVDetail[layerIndex], Styles.UVDetailMappingText);
-            }
-            else if (uvBaseMapping == UVBaseMapping.Planar)
+            if (uvBaseMapping == UVBaseMapping.Planar)
             {
                 EditorGUILayout.LabelField(Styles.UVDetailMappingText.text + ": Planar");
             }
             else if (uvBaseMapping == UVBaseMapping.Triplanar)
             {
                 EditorGUILayout.LabelField(Styles.UVDetailMappingText.text + ": Triplanar");
+            }
+            else
+            {
+                m_MaterialEditor.ShaderProperty(UVDetail[layerIndex], Styles.UVDetailMappingText);
             }
 
             // Setup the UVSet for detail, if planar/triplanar is use for base, it will override the mapping of detail (See shader code)

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
@@ -28,8 +28,8 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             public static GUIContent heightMapText = new GUIContent("Height Map (R)", "Height Map.\nFor floating point textures, min, max and base value should be 0, 1 and 0.");
             public static GUIContent heightMapCenterText = new GUIContent("Height Map Base", "Base of the heightmap in the texture (between 0 and 1)");
-            public static GUIContent heightMapMinText = new GUIContent("Height Min", "Minimum value in the heightmap (in world units)");
-            public static GUIContent heightMapMaxText = new GUIContent("Height Max", "Maximum value in the heightmap (in world units)");
+            public static GUIContent heightMapMinText = new GUIContent("Height Min (cm)", "Minimum value in the heightmap (in centimeters)");
+            public static GUIContent heightMapMaxText = new GUIContent("Height Max (cm)", "Maximum value in the heightmap (in centimeters)");
 
             public static GUIContent tangentMapText = new GUIContent("Tangent Map", "Tangent Map (BC7/BC5/DXT5(nm))");
             public static GUIContent tangentMapOSText = new GUIContent("Tangent Map OS", "Tangent Map (BC7/DXT1/RGB)");
@@ -420,7 +420,7 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
                 EditorGUI.indentLevel++;
                 m_MaterialEditor.ShaderProperty(heightMin[layerIndex], Styles.heightMapMinText);
                 m_MaterialEditor.ShaderProperty(heightMax[layerIndex], Styles.heightMapMaxText);
-                heightAmplitude[layerIndex].floatValue = heightMax[layerIndex].floatValue - heightMin[layerIndex].floatValue;
+                heightAmplitude[layerIndex].floatValue = (heightMax[layerIndex].floatValue - heightMin[layerIndex].floatValue) * 0.01f; // Conversion centimeters to meters.
                 m_MaterialEditor.ShaderProperty(heightCenter[layerIndex], Styles.heightMapCenterText);
                 EditorGUI.showMixedValue = false;
                 EditorGUI.indentLevel--;

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Editor/LitUI.cs
@@ -456,14 +456,13 @@ namespace UnityEditor.Experimental.Rendering.HDPipeline
 
             UVBaseMapping uvBaseMapping = (UVBaseMapping)UVBase[layerIndex].floatValue;
 
-            // UVSet0 is always set, planar and triplanar will override it.
             float X, Y, Z, W;
             X = (uvBaseMapping == UVBaseMapping.UV0) ? 1.0f : 0.0f;
             Y = (uvBaseMapping == UVBaseMapping.UV1) ? 1.0f : 0.0f;
             Z = (uvBaseMapping == UVBaseMapping.UV2) ? 1.0f : 0.0f;
             W = (uvBaseMapping == UVBaseMapping.UV3) ? 1.0f : 0.0f;
 
-            UVMappingMask[layerIndex].colorValue = (layerIndex == 0) ? new Color(1.0f, 0.0f, 0.0f, 0.0f) : new Color(X, Y, Z, W); // Special case for Main Layer and Blend Mask, only UV0. As Layer0 is shared by both here, need to force X to 1.0 in all case
+            UVMappingMask[layerIndex].colorValue = new Color(X, Y, Z, W);
             if ((uvBaseMapping == UVBaseMapping.Planar) || (uvBaseMapping == UVBaseMapping.Triplanar))
             {
                 m_MaterialEditor.ShaderProperty(TexWorldScale[layerIndex], Styles.texWorldScaleText);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.shader
@@ -12,6 +12,8 @@ Shader "HDRenderPipeline/Lit"
         _Metallic("_Metallic", Range(0.0, 1.0)) = 0
         _Smoothness("Smoothness", Range(0.0, 1.0)) = 1.0
         _MaskMap("MaskMap", 2D) = "white" {}
+        _SmoothnessRemapMin("SmoothnessRemapMin", Float) = 0.0
+        _SmoothnessRemapMax("SmoothnessRemapMax", Float) = 1.0
 
         _SpecularOcclusionMap("SpecularOcclusion", 2D) = "white" {}
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitData.hlsl
@@ -168,8 +168,7 @@ void GetLayerTexCoord(float2 texCoord0, float2 texCoord1, float2 texCoord2, floa
 #endif
 
     // Be sure that the compiler is aware that we don't use UV1 to UV3 for main layer so it can optimize code
-    _UVMappingMask = float4(1.0, 0.0, 0.0, 0.0);
-    ComputeLayerTexCoord(   texCoord0, texCoord1, texCoord2, texCoord3,
+    ComputeLayerTexCoord(   texCoord0, texCoord1, texCoord2, texCoord3, float4(1.0, 0.0, 0.0, 0.0), _UVDetailsMappingMask,
                             positionWS, mappingType, _TexWorldScale, layerTexCoord);
 }
 
@@ -606,12 +605,9 @@ void GetLayerTexCoord(float2 texCoord0, float2 texCoord1, float2 texCoord2, floa
     mappingType = UV_MAPPING_TRIPLANAR;
 #endif
 
-    // Be sure that the compiler is aware that we don't use UV1 to UV3 for main layer and blend mask so it can optimize code
-    // Note: Blend mask have its dedicated mapping and tiling. And as Main layer it only use UV0
-    _UVMappingMask0 = float4(1.0, 0.0, 0.0, 0.0);
-
+    // Note: Blend mask have its dedicated mapping and tiling. 
     // To share code, we simply call the regular code from the main layer for it then save the result, then do regular call for all layers.
-    ComputeLayerTexCoord0(  texCoord0, float2(0.0, 0.0), float2(0.0, 0.0), float2(0.0, 0.0),
+    ComputeLayerTexCoord0(  texCoord0, texCoord1, texCoord2, texCoord3, _UVMappingMaskBlendMask, _UVMappingMaskBlendMask,
                             positionWS, mappingType, _TexWorldScaleBlendMask, layerTexCoord, _LayerTilingBlendMask);
 
     layerTexCoord.blendMask = layerTexCoord.base0;
@@ -633,7 +629,7 @@ void GetLayerTexCoord(float2 texCoord0, float2 texCoord1, float2 texCoord2, floa
     mappingType = UV_MAPPING_TRIPLANAR;
 #endif
 
-    ComputeLayerTexCoord0(  texCoord0, float2(0.0, 0.0), float2(0.0, 0.0), float2(0.0, 0.0),
+    ComputeLayerTexCoord0(  texCoord0, texCoord1, texCoord2, texCoord3, _UVMappingMask0, _UVDetailsMappingMask0,
                             positionWS, mappingType, _TexWorldScale0, layerTexCoord, 1.0
                             #if !defined(_MAIN_LAYER_INFLUENCE_MODE)
                             * tileObjectScale  // We only affect layer0 in case we are not in influence mode (i.e we should not change the base object)
@@ -646,7 +642,7 @@ void GetLayerTexCoord(float2 texCoord0, float2 texCoord1, float2 texCoord2, floa
 #elif defined(_LAYER_MAPPING_TRIPLANAR1)
     mappingType = UV_MAPPING_TRIPLANAR;
 #endif
-    ComputeLayerTexCoord1(  texCoord0, texCoord1, texCoord2, texCoord3,
+    ComputeLayerTexCoord1(  texCoord0, texCoord1, texCoord2, texCoord3, _UVMappingMask1, _UVDetailsMappingMask1,
                             positionWS, mappingType, _TexWorldScale1, layerTexCoord, tileObjectScale);
 
     mappingType = UV_MAPPING_UVSET;
@@ -655,7 +651,7 @@ void GetLayerTexCoord(float2 texCoord0, float2 texCoord1, float2 texCoord2, floa
 #elif defined(_LAYER_MAPPING_TRIPLANAR2)
     mappingType = UV_MAPPING_TRIPLANAR;
 #endif
-    ComputeLayerTexCoord2(  texCoord0, texCoord1, texCoord2, texCoord3,
+    ComputeLayerTexCoord2(  texCoord0, texCoord1, texCoord2, texCoord3, _UVMappingMask2, _UVDetailsMappingMask2,
                             positionWS, mappingType, _TexWorldScale2, layerTexCoord, tileObjectScale);
 
     mappingType = UV_MAPPING_UVSET;
@@ -664,7 +660,7 @@ void GetLayerTexCoord(float2 texCoord0, float2 texCoord1, float2 texCoord2, floa
 #elif defined(_LAYER_MAPPING_TRIPLANAR3)
     mappingType = UV_MAPPING_TRIPLANAR;
 #endif
-    ComputeLayerTexCoord3(  texCoord0, texCoord1, texCoord2, texCoord3,
+    ComputeLayerTexCoord3(  texCoord0, texCoord1, texCoord2, texCoord3, _UVMappingMask3, _UVDetailsMappingMask3,
                             positionWS, mappingType, _TexWorldScale3, layerTexCoord, tileObjectScale);
 }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataInternal.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataInternal.hlsl
@@ -160,10 +160,11 @@ float ADD_IDX(GetSurfaceData)(FragInputs input, LayerTexCoord layerTexCoord, out
 
 #if defined(_MASKMAP_IDX)
     surfaceData.perceptualSmoothness = SAMPLE_UVMAPPING_TEXTURE2D(ADD_IDX(_MaskMap), SAMPLER_MASKMAP_IDX, ADD_IDX(layerTexCoord.base)).a;
+    surfaceData.perceptualSmoothness = lerp(ADD_IDX(_SmoothnessRemapMin), ADD_IDX(_SmoothnessRemapMax), surfaceData.perceptualSmoothness);
 #else
-    surfaceData.perceptualSmoothness = 1.0;
+    surfaceData.perceptualSmoothness = ADD_IDX(_Smoothness);
 #endif
-    surfaceData.perceptualSmoothness *= ADD_IDX(_Smoothness);
+
 #ifdef _DETAIL_MAP_IDX
     surfaceData.perceptualSmoothness *= LerpWhiteTo(2.0 * saturate(detailSmoothness * ADD_IDX(_DetailSmoothnessScale)), detailMask);
 #endif

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataInternal.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitDataInternal.hlsl
@@ -1,20 +1,20 @@
-void ADD_IDX(ComputeLayerTexCoord)( float2 texCoord0, float2 texCoord1, float2 texCoord2, float2 texCoord3,
+void ADD_IDX(ComputeLayerTexCoord)( float2 texCoord0, float2 texCoord1, float2 texCoord2, float2 texCoord3, float4 uvMappingMask, float4 uvMappingMaskDetail,
                                     float3 positionWS, int mappingType, float worldScale, inout LayerTexCoord layerTexCoord, float additionalTiling = 1.0)
 {
     // Handle uv0, uv1, uv2, uv3 based on _UVMappingMask weight (exclusif 0..1)
-    float2 uvBase = ADD_IDX(_UVMappingMask).x * texCoord0 +
-                    ADD_IDX(_UVMappingMask).y * texCoord1 +
-                    ADD_IDX(_UVMappingMask).z * texCoord2 +
-                    ADD_IDX(_UVMappingMask).w * texCoord3;
+    float2 uvBase = uvMappingMask.x * texCoord0 +
+                    uvMappingMask.y * texCoord1 +
+                    uvMappingMask.z * texCoord2 +
+                    uvMappingMask.w * texCoord3;
 
     // Only used with layered, allow to have additional tiling
     uvBase *= additionalTiling.xx;
 
 
-    float2 uvDetails =  ADD_IDX(_UVDetailsMappingMask).x * texCoord0 +
-                        ADD_IDX(_UVDetailsMappingMask).y * texCoord1 +
-                        ADD_IDX(_UVDetailsMappingMask).z * texCoord2 +
-                        ADD_IDX(_UVDetailsMappingMask).w * texCoord3;
+    float2 uvDetails =  uvMappingMaskDetail.x * texCoord0 +
+                        uvMappingMaskDetail.y * texCoord1 +
+                        uvMappingMaskDetail.z * texCoord2 +
+                        uvMappingMaskDetail.w * texCoord3;
 
     uvDetails *= additionalTiling.xx;
 
@@ -55,25 +55,25 @@ void ADD_IDX(ComputeLayerTexCoord)( float2 texCoord0, float2 texCoord1, float2 t
     #ifdef SURFACE_GRADIENT
     // This part is only relevant for normal mapping with UV_MAPPING_UVSET
     // Note: This code work only in pixel shader (as we rely on ddx), it should not be use in other context
-    ADD_IDX(layerTexCoord.base).tangentWS = ADD_IDX(_UVMappingMask).x * layerTexCoord.vertexTangentWS0 +
-                                            ADD_IDX(_UVMappingMask).y * layerTexCoord.vertexTangentWS1 +
-                                            ADD_IDX(_UVMappingMask).z * layerTexCoord.vertexTangentWS2 +
-                                            ADD_IDX(_UVMappingMask).w * layerTexCoord.vertexTangentWS3;
+    ADD_IDX(layerTexCoord.base).tangentWS = uvMappingMask.x * layerTexCoord.vertexTangentWS0 +
+                                            uvMappingMask.y * layerTexCoord.vertexTangentWS1 +
+                                            uvMappingMask.z * layerTexCoord.vertexTangentWS2 +
+                                            uvMappingMask.w * layerTexCoord.vertexTangentWS3;
 
-    ADD_IDX(layerTexCoord.base).bitangentWS =   ADD_IDX(_UVMappingMask).x * layerTexCoord.vertexBitangentWS0 +
-                                                ADD_IDX(_UVMappingMask).y * layerTexCoord.vertexBitangentWS1 +
-                                                ADD_IDX(_UVMappingMask).z * layerTexCoord.vertexBitangentWS2 +
-                                                ADD_IDX(_UVMappingMask).w * layerTexCoord.vertexBitangentWS3;
+    ADD_IDX(layerTexCoord.base).bitangentWS =   uvMappingMask.x * layerTexCoord.vertexBitangentWS0 +
+                                                uvMappingMask.y * layerTexCoord.vertexBitangentWS1 +
+                                                uvMappingMask.z * layerTexCoord.vertexBitangentWS2 +
+                                                uvMappingMask.w * layerTexCoord.vertexBitangentWS3;
 
-    ADD_IDX(layerTexCoord.details).tangentWS =  ADD_IDX(_UVDetailsMappingMask).x * layerTexCoord.vertexTangentWS0 +
-                                                ADD_IDX(_UVDetailsMappingMask).y * layerTexCoord.vertexTangentWS1 +
-                                                ADD_IDX(_UVDetailsMappingMask).z * layerTexCoord.vertexTangentWS2 +
-                                                ADD_IDX(_UVDetailsMappingMask).w * layerTexCoord.vertexTangentWS3;
+    ADD_IDX(layerTexCoord.details).tangentWS =  uvMappingMaskDetail.x * layerTexCoord.vertexTangentWS0 +
+                                                uvMappingMaskDetail.y * layerTexCoord.vertexTangentWS1 +
+                                                uvMappingMaskDetail.z * layerTexCoord.vertexTangentWS2 +
+                                                uvMappingMaskDetail.w * layerTexCoord.vertexTangentWS3;
 
-    ADD_IDX(layerTexCoord.details).bitangentWS =    ADD_IDX(_UVDetailsMappingMask).x * layerTexCoord.vertexBitangentWS0 +
-                                                    ADD_IDX(_UVDetailsMappingMask).y * layerTexCoord.vertexBitangentWS1 +
-                                                    ADD_IDX(_UVDetailsMappingMask).z * layerTexCoord.vertexBitangentWS2 +
-                                                    ADD_IDX(_UVDetailsMappingMask).w * layerTexCoord.vertexBitangentWS3;
+    ADD_IDX(layerTexCoord.details).bitangentWS =    uvMappingMaskDetail.x * layerTexCoord.vertexBitangentWS0 +
+                                                    uvMappingMaskDetail.y * layerTexCoord.vertexBitangentWS1 +
+                                                    uvMappingMaskDetail.z * layerTexCoord.vertexBitangentWS2 +
+                                                    uvMappingMaskDetail.w * layerTexCoord.vertexBitangentWS3;
     #endif
 }
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitProperties.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitProperties.hlsl
@@ -118,6 +118,8 @@ float4 _BaseColorMap_ST;
 
 float _Metallic;
 float _Smoothness;
+float _SmoothnessRemapMin;
+float _SmoothnessRemapMax;
 
 float _NormalScale;
 
@@ -157,6 +159,8 @@ float4 _BaseColorMap3_ST;
 
 PROP_DECL(float, _Metallic);
 PROP_DECL(float, _Smoothness);
+PROP_DECL(float, _SmoothnessRemapMin);
+PROP_DECL(float, _SmoothnessRemapMax);
 PROP_DECL(float, _NormalScale);
 float4 _NormalMap0_TexelSize; // Unity facility. This will provide the size of the base normal to the shader
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitProperties.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitProperties.hlsl
@@ -197,6 +197,7 @@ float _HeightTransition;
 
 float _TexWorldScaleBlendMask;
 PROP_DECL(float, _TexWorldScale);
+float4 _UVMappingMaskBlendMask;
 PROP_DECL(float4, _UVMappingMask);
 PROP_DECL(float4, _UVDetailsMappingMask);
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/LitTessellation.shader
@@ -12,6 +12,8 @@ Shader "HDRenderPipeline/LitTessellation"
         _Metallic("_Metallic", Range(0.0, 1.0)) = 0
         _Smoothness("Smoothness", Range(0.0, 1.0)) = 1.0
         _MaskMap("MaskMap", 2D) = "white" {}
+        _SmoothnessRemapMin("SmoothnessRemapMin", Float) = 0.0
+        _SmoothnessRemapMax("SmoothnessRemapMax", Float) = 1.0
 
         _SpecularOcclusionMap("SpecularOcclusion", 2D) = "white" {}
 


### PR DESCRIPTION
- Min/Max for heightmaps are now in centimeters
- Unlocked UV choice for Main Layer and BlendMask
- Moved at the bottom the material References UI and added the possibility not to synchronize UV related parameters.