### PR TITLE
Fix light culling while rendering reflection probes

### DIFF
--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/LightingConvexHullUtils.hlsl
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/LightingConvexHullUtils.hlsl
@@ -76,12 +76,11 @@ void GetPlane(out float3 p0, out float3 vN, const float3 boxX, const float3 boxY
 
     if (bIsSideQuad) { vA2 *= (iAbsSide == 0 ? scaleXY.x : scaleXY.y); vB2 *= (iAbsSide == 0 ? scaleXY.y : scaleXY.x); }
 
-    p0 = center + (vA + vB - vC);       // center + vA is center of face when scaleXY is 1.0
-    float3 vNout = cross( vB2, 0.5*(vA-vA2) - vC );
+    float3 v0 = vA + vB - vC;   // vector from center to p0
+    p0 = center + v0;           // center + vA is center of face when scaleXY is 1.0
 
-#if USE_LEFT_HAND_CAMERA_SPACE
-    vNout = -vNout;
-#endif
+    float3 n0    = cross(vB2, 0.5 * (vA - vA2) - vC);
+    float3 vNout = dot(n0,v0) < 0.0 ? (-n0) : n0;
 
     vN = vNout;
 }

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -972,19 +972,16 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
                 else if (gpuLightType == GPULightType.Point)
                 {
-                    bool isNegDeterminant = Vector3.Dot(worldToView.GetColumn(0), Vector3.Cross(worldToView.GetColumn(1), worldToView.GetColumn(2))) < 0.0f; // 3x3 Determinant.
-
-                    bound.center = positionVS;
-                    bound.boxAxisX.Set(range, 0, 0);
-                    bound.boxAxisY.Set(0, range, 0);
-                    bound.boxAxisZ.Set(0, 0, isNegDeterminant ? (-range) : range);    // transform to camera space (becomes a left hand coordinate frame in Unity since Determinant(worldToView)<0)
-                    bound.scaleXY.Set(1.0f, 1.0f);
-                    bound.radius = range;
-
-                    // represents a left hand coordinate system in world space since det(worldToView)<0
                     Vector3 vx = xAxisVS;
                     Vector3 vy = yAxisVS;
                     Vector3 vz = zAxisVS;
+
+                    bound.center   = positionVS;
+                    bound.boxAxisX = vx * range;
+                    bound.boxAxisY = vy * range;
+                    bound.boxAxisZ = vz * range;
+                    bound.scaleXY.Set(1.0f, 1.0f);
+                    bound.radius = range;
 
                     // fill up ldata
                     lightVolumeData.lightAxisX = vx;

--- a/TestbedPipelines/Fptl/FptlLighting.cs
+++ b/TestbedPipelines/Fptl/FptlLighting.cs
@@ -792,18 +792,17 @@ namespace UnityEngine.Experimental.Rendering.Fptl
                         light.sliceIndex = m_CubeCookieTexArray.FetchSlice(cl.light.cookie);
                     }
 
-                    bound.center = worldToView.MultiplyPoint(lightPos);
-                    bound.boxAxisX.Set(range, 0, 0);
-                    bound.boxAxisY.Set(0, range, 0);
-                    bound.boxAxisZ.Set(0, 0, isNegDeterminant ? (-range) : range);    // transform to camera space (becomes a left hand coordinate frame in Unity since Determinant(worldToView)<0)
-                    bound.scaleXY.Set(1.0f, 1.0f);
-                    bound.radius = range;
-
-                    // represents a left hand coordinate system in world space since det(worldToView)<0
                     var lightToView = worldToView * lightToWorld;
                     Vector3 vx = lightToView.GetColumn(0);
                     Vector3 vy = lightToView.GetColumn(1);
                     Vector3 vz = lightToView.GetColumn(2);
+
+                    bound.center   = worldToView.MultiplyPoint(lightPos);
+                    bound.boxAxisX = vx * range;
+                    bound.boxAxisY = vy * range;
+                    bound.boxAxisZ = vz * range;
+                    bound.scaleXY.Set(1.0f, 1.0f);
+                    bound.radius = range;
 
                     // fill up ldata
                     light.lightType = (uint)LightDefinitions.SPHERE_LIGHT;

--- a/TestbedPipelines/Fptl/LightingConvexHullUtils.hlsl
+++ b/TestbedPipelines/Fptl/LightingConvexHullUtils.hlsl
@@ -79,12 +79,11 @@ void GetPlane(out float3 p0, out float3 vN, const float3 boxX, const float3 boxY
 
     if (bIsSideQuad) { vA2 *= (iAbsSide == 0 ? scaleXY.x : scaleXY.y); vB2 *= (iAbsSide == 0 ? scaleXY.y : scaleXY.x); }
 
-    p0 = center + (vA + vB - vC);       // center + vA is center of face when scaleXY is 1.0
-    float3 vNout = cross( vB2, 0.5*(vA-vA2) - vC );
+    float3 v0 = vA + vB - vC;   // vector from center to p0
+    p0 = center + v0;           // center + vA is center of face when scaleXY is 1.0
 
-#if USE_LEFTHAND_CAMERASPACE
-    vNout = -vNout;
-#endif
+    float3 n0    = cross(vB2, 0.5 * (vA - vA2) - vC);
+    float3 vNout = dot(n0,v0) < 0.0 ? (-n0) : n0;
 
     vN = vNout;
 }


### PR DESCRIPTION
'camera.worldToCameraMatrix' has a positive determinant (flip Y and Z) when rendering reflection probes, yet has a negative determinant (flip Z) in the case of the regular scene rendering.