### PR TITLE
Improved ProfilingSample API

### DIFF
--- a/ScriptableRenderPipeline/Core/ProfilingSample.cs
+++ b/ScriptableRenderPipeline/Core/ProfilingSample.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine.Rendering;
 
 namespace UnityEngine.Experimental.Rendering
@@ -10,10 +10,29 @@ namespace UnityEngine.Experimental.Rendering
 
         bool m_Disposed;
 
-        public ProfilingSample(string name, CommandBuffer cmd)
+        public ProfilingSample(CommandBuffer cmd, string name)
         {
             this.cmd = cmd;
             this.name = name;
+            m_Disposed = false;
+            cmd.BeginSample(name);
+        }
+
+        // Shortcut to string.Format() using only one argument (reduces Gen0 GC pressure)
+        public ProfilingSample(CommandBuffer cmd, string format, object arg)
+        {
+            this.cmd = cmd;
+            name = string.Format(format, arg);
+            m_Disposed = false;
+            cmd.BeginSample(name);
+        }
+
+        // Shortcut to string.Format() with variable amount of arguments - for performance critical
+        // code you should pre-build & cache the marker name instead of using this
+        public ProfilingSample(CommandBuffer cmd, string format, params object[] args)
+        {
+            this.cmd = cmd;
+            name = string.Format(format, args);
             m_Disposed = false;
             cmd.BeginSample(name);
         }

--- a/ScriptableRenderPipeline/Core/Shadow/Shadow.cs
+++ b/ScriptableRenderPipeline/Core/Shadow/Shadow.cs
@@ -474,7 +474,7 @@ namespace UnityEngine.Experimental.Rendering
             if (m_ActiveEntriesCount == 0)
                 return;
 
-            var profilingSample = new ProfilingSample(string.Format("Shadowmap{0}",m_TexSlot), cmd);
+            var profilingSample = new ProfilingSample(cmd, "Shadowmap{0}", m_TexSlot);
 
             string cbName = "";
             if (!string.IsNullOrEmpty( m_ShaderKeyword ) )
@@ -1394,7 +1394,7 @@ namespace UnityEngine.Experimental.Rendering
 
         public override void RenderShadows( FrameId frameId, ScriptableRenderContext renderContext, CommandBuffer cmd, CullResults cullResults, List<VisibleLight> lights)
         {
-            using (new ProfilingSample("Render Shadows", cmd))
+            using (new ProfilingSample(cmd, "Render Shadows"))
             {
                 foreach( var sm in m_Shadowmaps )
                 {

--- a/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/HDRenderPipeline.cs
@@ -481,7 +481,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void PushGlobalParams(HDCamera hdCamera, CommandBuffer cmd, SubsurfaceScatteringSettings sssParameters)
         {
-            using (new ProfilingSample("Push Global Parameters", cmd))
+            using (new ProfilingSample(cmd, "Push Global Parameters"))
             {
                 hdCamera.SetupGlobalParams(cmd);
 
@@ -549,11 +549,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         private void CopyDepthBufferIfNeeded(CommandBuffer cmd)
         {
-            using (new ProfilingSample(NeedDepthBufferCopy() ? "Copy DepthBuffer" : "Set DepthBuffer", cmd))
+            using (new ProfilingSample(cmd, NeedDepthBufferCopy() ? "Copy DepthBuffer" : "Set DepthBuffer"))
             {
                 if (NeedDepthBufferCopy())
                 {
-                    using (new ProfilingSample("Copy depth-stencil buffer", cmd))
+                    using (new ProfilingSample(cmd, "Copy depth-stencil buffer"))
                     {
                         cmd.CopyTexture(m_CameraDepthStencilBufferRT, m_CameraDepthBufferCopyRT);
                     }
@@ -567,7 +567,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         {
             if (NeedStencilBufferCopy())
             {
-                using (new ProfilingSample("Copy StencilBuffer", cmd))
+                using (new ProfilingSample(cmd, "Copy StencilBuffer"))
                 {
                     cmd.SetRandomWriteTarget(1, GetHTile());
                     // Our method of exporting the stencil requires one pass per unique stencil value.
@@ -691,7 +691,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // TODO: Add another path dedicated to planar reflection / real time cubemap that implement simpler lighting
                 // It is up to the users to only send unlit object for this camera path
 
-                using (new ProfilingSample("Forward", cmd))
+                using (new ProfilingSample(cmd, "Forward"))
                 {
                     CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT, ClearFlag.Color | ClearFlag.Depth);
                     ShaderPassName[] arrayShaderPassName = { HDShaderPassNames.m_ForwardName };
@@ -723,7 +723,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             }
             else
             {
-                using (new ProfilingSample("Build Light list and render shadows", cmd))
+                using (new ProfilingSample(cmd, "Build Light list and render shadows"))
                 {
                     // TODO: Everything here (SSAO, Shadow, Build light list, deffered shadow, material and light classification can be parallelize with Async compute)
                     m_SsaoEffect.Render(ssaoSettingsToUse, this, hdCamera, renderContext, cmd, m_Asset.renderingSettings.useForwardRenderingOnly);
@@ -778,7 +778,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Planar and real time cubemap doesn't need post process and render in FP16
                 if (camera.cameraType == CameraType.Reflection)
                 {
-                    using (new ProfilingSample("Blit to final RT", cmd))
+                    using (new ProfilingSample(cmd, "Blit to final RT"))
                     {
                         // Simple blit
                         cmd.Blit(m_CameraColorBufferRT, BuiltinRenderTextureType.CameraTarget);
@@ -939,7 +939,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (addDepthPrepass == false && addForwardOnlyOpaqueDepthPrepass == false)
                 return;
 
-            using (new ProfilingSample(addDepthPrepass ? "Depth Prepass" : "Depth Prepass forward opaque ", cmd))
+            using (new ProfilingSample(cmd, addDepthPrepass ? "Depth Prepass" : "Depth Prepass forward opaque"))
             {
                 // Default depth prepass (forward and deferred) will render all opaque geometry.
                 RenderQueueRange renderQueueRange = RenderQueueRange.opaque;
@@ -962,7 +962,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 return;
 
-            using (new ProfilingSample(m_CurrentDebugDisplaySettings.IsDebugDisplayEnabled() ? "GBufferDebugDisplay" : "GBuffer", cmd))
+            using (new ProfilingSample(cmd, m_CurrentDebugDisplaySettings.IsDebugDisplayEnabled() ? "GBufferDebugDisplay" : "GBuffer"))
             {
                 // setup GBuffer for rendering
                 CoreUtils.SetRenderTarget(cmd, m_gbufferManager.GetGBuffers(), m_CameraDepthStencilBufferRT);
@@ -996,11 +996,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void RenderDebugViewMaterial(CullResults cull, HDCamera hdCamera, ScriptableRenderContext renderContext, CommandBuffer cmd)
         {
-            using (new ProfilingSample("DisplayDebug ViewMaterial", cmd))
+            using (new ProfilingSample(cmd, "DisplayDebug ViewMaterial"))
             {
                 if (m_CurrentDebugDisplaySettings.materialDebugSettings.IsDebugGBufferEnabled() && !m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 {
-                    using (new ProfilingSample("DebugViewMaterialGBuffer", cmd))
+                    using (new ProfilingSample(cmd, "DebugViewMaterialGBuffer"))
                     {
                         CoreUtils.DrawFullScreen(cmd, m_DebugViewMaterialGBuffer, m_CameraColorBufferRT);
                     }
@@ -1018,7 +1018,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             // Last blit
             {
-                using (new ProfilingSample("Blit DebugView Material Debug", cmd))
+                using (new ProfilingSample(cmd, "Blit DebugView Material Debug"))
                 {
                     cmd.Blit(m_CameraColorBufferRT, BuiltinRenderTextureType.CameraTarget);
                 }
@@ -1059,7 +1059,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (!m_CurrentDebugDisplaySettings.renderingDebugSettings.enableSSSAndTransmission || m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 return;
 
-            using (new ProfilingSample("Subsurface Scattering", cmd))
+            using (new ProfilingSample(cmd, "Subsurface Scattering"))
             {
                 if (sssSettings.useDisneySSS)
                 {
@@ -1154,7 +1154,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 profileName = addForwardPass ? (renderOpaque ? "Forward Opaque" : "Forward Transparent") :  "Forward Only Opaque";
             }
 
-            using (new ProfilingSample(profileName, cmd))
+            using (new ProfilingSample(cmd, profileName))
             {
                 CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT);
 
@@ -1179,7 +1179,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
         // This is use to Display legacy shader with an error shader
         void RenderForwardError(CullResults cullResults, Camera camera, ScriptableRenderContext renderContext, CommandBuffer cmd, bool renderOpaque)
         {
-            using (new ProfilingSample("Render Forward Error", cmd))
+            using (new ProfilingSample(cmd, "Render Forward Error"))
             {
                 CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT);
 
@@ -1199,7 +1199,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void RenderVelocity(CullResults cullResults, HDCamera hdcam, ScriptableRenderContext renderContext, CommandBuffer cmd)
         {
-            using (new ProfilingSample("Velocity", cmd))
+            using (new ProfilingSample(cmd, "Velocity"))
             {
                 // If opaque velocity have been render during GBuffer no need to render it here
                 // TODO: Currently we can't render velocity vector into GBuffer, neither during forward pass (in case of forward opaque), so it is always a separate pass
@@ -1234,7 +1234,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (!m_CurrentDebugDisplaySettings.renderingDebugSettings.enableDistortion)
                 return;
 
-            using (new ProfilingSample("Distortion", cmd))
+            using (new ProfilingSample(cmd, "Distortion"))
             {
                 int w = camera.pixelWidth;
                 int h = camera.pixelHeight;
@@ -1250,7 +1250,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void RenderPostProcesses(Camera camera, CommandBuffer cmd, PostProcessLayer layer)
         {
-            using (new ProfilingSample("Post-processing", cmd))
+            using (new ProfilingSample(cmd, "Post-processing"))
             {
                 if (CoreUtils.IsPostProcessingActive(layer))
                 {
@@ -1310,7 +1310,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (camera.camera.cameraType == CameraType.Reflection || camera.camera.cameraType == CameraType.Preview)
                 return;
 
-            using (new ProfilingSample("Render Debug", cmd))
+            using (new ProfilingSample(cmd, "Render Debug"))
             {
                 // We make sure the depth buffer is bound because we need it to write depth at near plane for overlays otherwise the editor grid end up visible in them.
                 CoreUtils.SetRenderTarget(cmd, BuiltinRenderTextureType.CameraTarget, m_CameraDepthStencilBufferRT);
@@ -1348,11 +1348,11 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         void InitAndClearBuffer(HDCamera camera, CommandBuffer cmd)
         {
-            using (new ProfilingSample("InitAndClearBuffer", cmd))
+            using (new ProfilingSample(cmd, "InitAndClearBuffer"))
             {
                 // We clear only the depth buffer, no need to clear the various color buffer as we overwrite them.
                 // Clear depth/stencil and init buffers
-                using (new ProfilingSample("InitGBuffers and clear Depth/Stencil", cmd))
+                using (new ProfilingSample(cmd, "InitGBuffers and clear Depth/Stencil"))
                 {
                     // Init buffer
                     // With scriptable render loop we must allocate ourself depth and color buffer (We must be independent of backbuffer for now, hope to fix that later).
@@ -1375,7 +1375,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
 
                 // Clear the diffuse SSS lighting target
-                using (new ProfilingSample("Clear SSS diffuse target", cmd))
+                using (new ProfilingSample(cmd, "Clear SSS diffuse target"))
                 {
                     CoreUtils.SetRenderTarget(cmd, m_CameraSssDiffuseLightingBufferRT, ClearFlag.Color, Color.black);
                 }
@@ -1384,7 +1384,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 if (!sssSettings.useDisneySSS)
                 {
                     // Clear the SSS filtering target
-                    using (new ProfilingSample("Clear SSS filtering target", cmd))
+                    using (new ProfilingSample(cmd, "Clear SSS filtering target"))
                     {
                         CoreUtils.SetRenderTarget(cmd, m_CameraFilteringBuffer, ClearFlag.Color, Color.black);
                     }
@@ -1393,7 +1393,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 if (NeedStencilBufferCopy())
                 {
-                    using (new ProfilingSample("Clear stencil texture", cmd))
+                    using (new ProfilingSample(cmd, "Clear stencil texture"))
                     {
                         CoreUtils.SetRenderTarget(cmd, m_CameraStencilBufferCopyRT, ClearFlag.Color, Color.black);
                     }
@@ -1401,7 +1401,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 if (NeedHTileCopy())
                 {
-                    using (new ProfilingSample("Clear HTile", cmd))
+                    using (new ProfilingSample(cmd, "Clear HTile"))
                     {
                         CoreUtils.SetRenderTarget(cmd, m_HTileRT, ClearFlag.Color, Color.black);
                     }
@@ -1415,7 +1415,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // TEMP: As we are in development and have not all the setup pass we still clear the color in emissive buffer and gbuffer, but this will be removed later.
 
                 // Clear the HDR target
-                using (new ProfilingSample("Clear HDR target", cmd))
+                using (new ProfilingSample(cmd, "Clear HDR target"))
                 {
                     CoreUtils.SetRenderTarget(cmd, m_CameraColorBufferRT, m_CameraDepthStencilBufferRT, ClearFlag.Color, Color.black);
                 }
@@ -1423,7 +1423,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Clear GBuffers
                 if (!m_Asset.renderingSettings.ShouldUseForwardRenderingOnly())
                 {
-                    using (new ProfilingSample("Clear GBuffer", cmd))
+                    using (new ProfilingSample(cmd, "Clear GBuffer"))
                     {
                         CoreUtils.SetRenderTarget(cmd, m_gbufferManager.GetGBuffers(), m_CameraDepthStencilBufferRT, ClearFlag.Color, Color.black);
                     }

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/AmbientOcclusion/ScreenSpaceAmbientOcclusion.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/AmbientOcclusion/ScreenSpaceAmbientOcclusion.cs
@@ -59,7 +59,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             m_Material.SetFloat(Uniforms._Downsample, 1.0f / downsize);
             m_Material.SetFloat(Uniforms._SampleCount, settings.sampleCount);
 
-            using (new ProfilingSample("Screenspace ambient occlusion", cmd))
+            using (new ProfilingSample(cmd, "Screenspace ambient occlusion"))
             {
                 // AO estimation.
                 cmd.GetTemporaryRT(Uniforms._TempTex1, width / downsize, height / downsize, 0, kFilter, kTempFormat, kRWMode);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/TilePass/TilePass.cs
@@ -1828,7 +1828,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             public void PushGlobalParams(Camera camera, CommandBuffer cmd, ComputeShader computeShader, int kernelIndex, bool forceClustered = false)
             {
-                using (new ProfilingSample("Push Global Parameters", cmd))
+                using (new ProfilingSample(cmd, "Push Global Parameters"))
                 {
                     // Shadows
                     m_ShadowMgr.SyncData();
@@ -1869,7 +1869,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 if (lightingDebug.tileDebugByCategory == TileSettings.TileDebug.None)
                     return;
 
-                using (new ProfilingSample("Tiled Lighting Debug", cmd))
+                using (new ProfilingSample(cmd, "Tiled Lighting Debug"))
                 {
                     bool bUseClusteredForDeferred = !usingFptl;
 
@@ -1935,7 +1935,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 if (m_CurrentSunLight == null)
                     return;
 
-                using (new ProfilingSample("Deferred Directional", cmd))
+                using (new ProfilingSample(cmd, "Deferred Directional"))
                 {
                     hdCamera.SetupComputeShader(deferredDirectionalShadowComputeShader, cmd);
                     m_ShadowMgr.BindResources(cmd, deferredDirectionalShadowComputeShader, s_deferredDirectionalShadowKernel);
@@ -1971,9 +1971,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 string singlePassName = "SinglePass - Deferred Lighting Pass";
                 string SinglePassMRTName = "SinglePass - Deferred Lighting Pass MRT";
 
-                using (new ProfilingSample(m_TileSettings.enableTileAndCluster ?
-                                                            (options.outputSplitLighting ? tilePassMRTName : tilePassName) :
-                                                            (options.outputSplitLighting ? SinglePassMRTName : singlePassName), cmd))
+                using (new ProfilingSample(cmd, m_TileSettings.enableTileAndCluster ?
+                    (options.outputSplitLighting ? tilePassMRTName : tilePassName) :
+                    (options.outputSplitLighting ? SinglePassMRTName : singlePassName)))
                 {
                     var camera = hdCamera.camera;
 
@@ -2188,7 +2188,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 // Note: if we use render opaque with deferred tiling we need to render a opaque depth pass for these opaque objects
                 if (!m_TileSettings.enableTileAndCluster)
                 {
-                    using (new ProfilingSample("Forward pass", cmd))
+                    using (new ProfilingSample(cmd, "Forward pass"))
                     {
                         cmd.EnableShaderKeyword("LIGHTLOOP_SINGLE_PASS");
                         cmd.DisableShaderKeyword("LIGHTLOOP_TILE_PASS");
@@ -2199,7 +2199,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     // Only opaques can use FPTL, transparent must use clustered!
                     bool useFptl = renderOpaque && usingFptl;
 
-                    using (new ProfilingSample(useFptl ? "Forward Tiled pass" : "Forward Clustered pass", cmd))
+                    using (new ProfilingSample(cmd, useFptl ? "Forward Tiled pass" : "Forward Clustered pass"))
                     {
                         // say that we want to use tile of single loop
                         cmd.EnableShaderKeyword("LIGHTLOOP_TILE_PASS");
@@ -2213,7 +2213,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             public void RenderDebugOverlay(Camera camera, CommandBuffer cmd, DebugDisplaySettings debugDisplaySettings, ref float x, ref float y, float overlaySize, float width)
             {
                 LightingDebugSettings lightingDebug = debugDisplaySettings.lightingDebugSettings;
-                using (new ProfilingSample("Display Shadows", cmd))
+                using (new ProfilingSample(cmd, "Display Shadows"))
                 {
                     if (lightingDebug.shadowDebugMode == ShadowMapDebugMode.VisualizeShadowMap)
                     {

--- a/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Volumetrics/VolumetricLighting.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Lighting/Volumetrics/VolumetricLighting.cs
@@ -144,7 +144,7 @@ public partial class HDRenderPipeline : RenderPipeline
 
     void ClearVolumetricLightingBuffers(CommandBuffer cmd, bool isFirstFrame)
     {
-        using (new ProfilingSample("Clear volumetric lighting buffers", cmd))
+        using (new ProfilingSample(cmd, "Clear volumetric lighting buffers"))
         {
             CoreUtils.SetRenderTarget(cmd, m_VolumetricLightingBufferCurrentFrameRT, ClearFlag.Color, Color.black);
 
@@ -197,7 +197,7 @@ public partial class HDRenderPipeline : RenderPipeline
     {
         if (!SetGlobalVolumeProperties(m_VolumetricLightingEnabled, cmd, m_VolumetricLightingCS)) { return; }
 
-        using (new ProfilingSample("VolumetricLighting", cmd))
+        using (new ProfilingSample(cmd, "VolumetricLighting"))
         {
             bool enableClustered = m_Asset.tileSettings.enableClustered && m_Asset.tileSettings.enableTileAndCluster;
 

--- a/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Material/Lit/Lit.cs
@@ -299,7 +299,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             if (m_isInit)
                 return;
 
-            using (new ProfilingSample("Init PreFGD", cmd))
+            using (new ProfilingSample(cmd, "Init PreFGD"))
             {
                 CoreUtils.DrawFullScreen(cmd, m_InitPreFGD, new RenderTargetIdentifier(m_PreIntegratedFGD));
             }

--- a/ScriptableRenderPipeline/HDRenderPipeline/Sky/RuntimeFilterIBL.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Sky/RuntimeFilterIBL.cs
@@ -69,7 +69,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
                 m_ComputeGgxIblSampleDataCS.SetTexture(m_ComputeGgxIblSampleDataKernel, "output", m_GgxIblSampleData);
 
-                using (new ProfilingSample("Compute GGX IBL Sample Data", cmd))
+                using (new ProfilingSample(cmd, "Compute GGX IBL Sample Data"))
                 {
                     cmd.DispatchCompute(m_ComputeGgxIblSampleDataCS, m_ComputeGgxIblSampleDataKernel, 1, 1, 1);
                 }
@@ -135,7 +135,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
             int numRows = conditionalCdf.height;
 
-            using (new ProfilingSample("Build Probability Tables", cmd))
+            using (new ProfilingSample(cmd, "Build Probability Tables"))
             {
                 cmd.DispatchCompute(m_BuildProbabilityTablesCS, m_ConditionalDensitiesKernel, numRows, 1, 1);
                 cmd.DispatchCompute(m_BuildProbabilityTablesCS, m_MarginalRowDensitiesKernel, 1, 1, 1);

--- a/ScriptableRenderPipeline/HDRenderPipeline/Sky/SkyManager.cs
+++ b/ScriptableRenderPipeline/HDRenderPipeline/Sky/SkyManager.cs
@@ -322,7 +322,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         private void RenderCubemapGGXConvolution(CommandBuffer cmd, BuiltinSkyParameters builtinParams, SkySettings skyParams, Texture input, RenderTexture target)
         {
-            using (new ProfilingSample("Update Env: GGX Convolution", cmd))
+            using (new ProfilingSample(cmd, "Update Env: GGX Convolution"))
             {
                 int mipCount = 1 + (int)Mathf.Log(input.width, 2.0f);
                 if (mipCount < ((int)EnvConstants.SpecCubeLodStep + 1))
@@ -337,7 +337,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                 }
 
                 // Copy the first mip
-                using (new ProfilingSample("Copy Original Mip", cmd))
+                using (new ProfilingSample(cmd, "Copy Original Mip"))
                 {
                     for (int f = 0; f < 6; f++)
                     {
@@ -345,7 +345,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     }
                 }
 
-                using (new ProfilingSample("GGX Convolution", cmd))
+                using (new ProfilingSample(cmd, "GGX Convolution"))
                 {
                     if (m_useMIS && m_iblFilterGgx.SupportMIS)
                     {
@@ -369,7 +369,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             // We need one frame delay for this update to work since DynamicGI.UpdateEnvironment is executed directly but the renderloop is not (so we need to wait for the sky texture to be rendered first)
             if (m_NeedLowLevelUpdateEnvironment)
             {
-                using (new ProfilingSample("DynamicGI.UpdateEnvironment", cmd))
+                using (new ProfilingSample(cmd, "DynamicGI.UpdateEnvironment"))
                 {
                     // TODO: Properly send the cubemap to Enlighten. Currently workaround is to set the cubemap in a Skybox/cubemap material
                     m_StandardSkyboxMaterial.SetTexture("_Tex", m_SkyboxCubemapRT);
@@ -399,9 +399,9 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
                     (skySettings.updateMode == EnvironementUpdateMode.Realtime && m_CurrentUpdateTime > skySettings.updatePeriod)
                     )
                 {
-                    using (new ProfilingSample("Sky Environment Pass", cmd))
+                    using (new ProfilingSample(cmd, "Sky Environment Pass"))
                     {
-                        using (new ProfilingSample("Update Env: Generate Lighting Cubemap", cmd))
+                        using (new ProfilingSample(cmd, "Update Env: Generate Lighting Cubemap"))
                         {
                             // Render sky into a cubemap - doesn't happen every frame, can be controlled
                             // Note that m_SkyboxCubemapRT is created with auto-generate mipmap, it mean that here we have also our mipmap correctly box filtered for importance sampling.
@@ -431,7 +431,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
             {
                 if (m_SkyParametersHash != 0)
                 {
-                    using (new ProfilingSample("Reset Sky Environment", cmd))
+                    using (new ProfilingSample(cmd, "Reset Sky Environment"))
                     {
                         // Clear temp cubemap and redo GGX from black and then feed it to enlighten for default light probe.
                         CoreUtils.ClearCubemap(cmd, m_SkyboxCubemapRT, Color.black);
@@ -446,7 +446,7 @@ namespace UnityEngine.Experimental.Rendering.HDPipeline
 
         public void RenderSky(HDCamera camera, Light sunLight, RenderTargetIdentifier colorBuffer, RenderTargetIdentifier depthBuffer, CommandBuffer cmd)
         {
-            using (new ProfilingSample("Sky Pass", cmd))
+            using (new ProfilingSample(cmd, "Sky Pass"))
             {
                 if (IsSkyValid())
                 {


### PR DESCRIPTION
Changed the `ProfilingSample` constructor signature for coherency and added alternative constructors that can be used as shortcuts to `string.Format()` so you can do dynamic string building like:

```csharp
using (new ProfilingSample(cmd, "Rendering {0} - {1:00000}", "Butterfly", 42))
{
    // ...
}
```